### PR TITLE
Improvements frequency formating, bug fixing and several refactors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,5 +6,5 @@ root = true
 end_of_line = lf
 insert_final_newline = true
 charset = utf-8
-indent_style = tab
+indent_style = space
 indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ Makefile
 cmake_install.cmake
 install_manifest.txt
 out/
+Testing/
 
 # Linux desktop files
 .directory

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,13 +13,15 @@ set(BASE_SOURCE_FILES
     src/fq.c
     src/util.c)
 
-add_executable(fq src/main.c ${BASE_SOURCE_FILES})
+add_executable(fq src/main.c
+               ${BASE_SOURCE_FILES})
 
-set(TEST_SOURCE_FILES
-    test/util_t.c
-    test/test_fq.c)
+set(BASE_TEST_SOURCE_FILES
+    test/util_t.c)
 
-add_executable(test_fq ${TEST_SOURCE_FILES} ${BASE_SOURCE_FILES})
+add_executable(test_fq test/test_fq.c
+               ${BASE_TEST_SOURCE_FILES}
+               ${BASE_SOURCE_FILES})
 
 install(TARGETS fq
         DESTINATION ${CMAKE_INSTALL_PREFIX}/bin/)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,5 +29,6 @@ add_custom_target(clean-all
                        ${CMAKE_BINARY_DIR}/Makefile
                        ${CMAKE_BINARY_DIR}/CMakeFiles
                        ${CMAKE_BINARY_DIR}/install_manifest.txt
+                       ${CMAKE_BINARY_DIR}/cmake-build-debug
              && rmdir  ${CMAKE_BINARY_DIR}/out
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,12 +10,13 @@ include_directories("${CMAKE_SOURCE_DIR}/src")
 
 set(BASE_SOURCE_FILES
     src/freqlist.c
-    src/fq.c)
+    src/fq.c
+    src/util.c)
 
-add_executable(fq src/main.c ${BASE_SOURCE_FILES})
+add_executable(fq src/main.c ${BASE_SOURCE_FILES} src/util.c)
 
 set(TEST_SOURCE_FILES
-    test/test_util.c
+    test/util_t.c
     test/test_fq.c)
 
 add_executable(test_fq ${TEST_SOURCE_FILES} ${BASE_SOURCE_FILES})
@@ -30,5 +31,6 @@ add_custom_target(clean-all
                        ${CMAKE_BINARY_DIR}/CMakeFiles
                        ${CMAKE_BINARY_DIR}/cmake-build-debug
                        ${CMAKE_BINARY_DIR}/install_manifest.txt
+                       ${CMAKE_BINARY_DIR}/Testing
              && rmdir  ${CMAKE_BINARY_DIR}/out
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ add_custom_target(clean-all
                        ${CMAKE_BINARY_DIR}/cmake_install.cmake
                        ${CMAKE_BINARY_DIR}/Makefile
                        ${CMAKE_BINARY_DIR}/CMakeFiles
-                       ${CMAKE_BINARY_DIR}/install_manifest.txt
                        ${CMAKE_BINARY_DIR}/cmake-build-debug
+                       ${CMAKE_BINARY_DIR}/install_manifest.txt
              && rmdir  ${CMAKE_BINARY_DIR}/out
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ set(BASE_SOURCE_FILES
     src/fq.c
     src/util.c)
 
-add_executable(fq src/main.c ${BASE_SOURCE_FILES} src/util.c)
+add_executable(fq src/main.c ${BASE_SOURCE_FILES})
 
 set(TEST_SOURCE_FILES
     test/util_t.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.10)
 project(fq C)
+
+enable_testing()
 
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
@@ -13,19 +15,35 @@ set(BASE_SOURCE_FILES
     src/fq.c
     src/util.c)
 
+# Executable "fq"
 add_executable(fq src/main.c
                ${BASE_SOURCE_FILES})
 
 set(BASE_TEST_SOURCE_FILES
     test/util_t.c)
 
+# Executable with unit tests "test_fq"
 add_executable(test_fq test/test_fq.c
                ${BASE_TEST_SOURCE_FILES}
                ${BASE_SOURCE_FILES})
 
+# Install with `make install`
 install(TARGETS fq
         DESTINATION ${CMAKE_INSTALL_PREFIX}/bin/)
 
+# To trigger dependencies before `make test`
+set_property(DIRECTORY APPEND
+             PROPERTY TEST_INCLUDE_FILES
+             "${CMAKE_CURRENT_BINARY_DIR}/BuildTestTarget.cmake")
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/BuildTestTarget.cmake"
+     "execute_process(COMMAND \"${CMAKE_COMMAND}\""
+     " --build \"${CMAKE_BINARY_DIR}\""
+     " --config \"\$ENV{CMAKE_CONFIG_TYPE}\")")
+
+# Unit tests with `make test`
+add_test(test_fq ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test_fq)
+
+# To clean everything: compiled binaries and *make* files
 add_custom_target(clean-all
   make clean && rm -fR ${CMAKE_BINARY_DIR}/CMakeCache.txt
                        ${CMAKE_BINARY_DIR}/cmake_install.cmake
@@ -34,5 +52,5 @@ add_custom_target(clean-all
                        ${CMAKE_BINARY_DIR}/cmake-build-debug
                        ${CMAKE_BINARY_DIR}/install_manifest.txt
                        ${CMAKE_BINARY_DIR}/Testing
-             && rmdir  ${CMAKE_BINARY_DIR}/out
+             && rmdir  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
 )

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ To clean all the compiled binaries and the "Makefiles" files:
 
 ### Tests
 
-Tests are built with CHEAT <http://users.jyu.fi/~sapekiis/cheat/index.html>,
+Tests are built with CHEAT <https://github.com/Tuplanolla/cheat>,
 a unit testing framework for C/C++ programming language.
 
 To run the tests, first build the project and then execute:

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ The project uses *CMakes* to build the executable.
 
        $ make
 
-3. Then execute with:
+3. Then execute with (use with `-h` to see available options):
 
        $ out/fq
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Executing it with the `-v` (verbose) argument,
 it iterates the file byte by byte and shows the
 frequencies each time:
 
-	$ echo "banana" | fq -v
+	$ echo 'banana!!' | fq -v
 	Symbol    Frequency   Pos
 	-------------------------
 	'a' 61            1     0 *
@@ -67,7 +67,7 @@ frequencies each time:
 	
 	Symbol    Frequency   Pos
 	-------------------------
-	'a' 61            2     0 *
+	'a' 61            2     0 <
 	'b' 62            1     1
 	'n' 6E            1     2
 	-------------------------
@@ -77,7 +77,7 @@ frequencies each time:
 	Symbol    Frequency   Pos
 	-------------------------
 	'a' 61            2     0
-	'n' 6E            2     1 *
+	'n' 6E            2     1 ^ (+1)
 	'b' 62            1     2
 	-------------------------
 	Size: 5 - Number of symbols: 3
@@ -85,7 +85,7 @@ frequencies each time:
 	
 	Symbol    Frequency   Pos
 	-------------------------
-	'a' 61            3     0 *
+	'a' 61            3     0 <
 	'n' 6E            2     1
 	'b' 62            1     2
 	-------------------------
@@ -96,21 +96,43 @@ frequencies each time:
 	-------------------------
 	'a' 61            3     0
 	'n' 6E            2     1
-	'.' 0A            1     2 *
+	'!' 21            1     2 *
 	'b' 62            1     3
 	-------------------------
 	Size: 7 - Number of symbols: 4
+	
+	
+	Symbol    Frequency   Pos
+	-------------------------
+	'a' 61            3     0
+	'!' 21            2     1 ^ (+1)
+	'n' 6E            2     2
+	'b' 62            1     3
+	-------------------------
+	Size: 8 - Number of symbols: 4
+	
+	
+	Symbol    Frequency   Pos
+	-------------------------
+	'a' 61            3     0
+	'!' 21            2     1
+	'n' 6E            2     2
+	'.' 0A            1     3 *
+	'b' 62            1     4
+	-------------------------
+	Size: 9 - Number of symbols: 5
 	
 	
 	> Final frequency table
 	Symbol    Frequency   Pos
 	-------------------------
 	'a' 61            3     0
-	'n' 6E            2     1
-	'.' 0A            1     2
-	'b' 62            1     3
+	'!' 21            2     1
+	'n' 6E            2     2
+	'.' 0A            1     3
+	'b' 62            1     4
 	-------------------------
-	Size: 7 - Number of symbols: 4
+	Size: 9 - Number of symbols: 5
 
 
 Build and execute

--- a/README.md
+++ b/README.md
@@ -1,37 +1,42 @@
 "Frequency Counter" project
 ===========================
 
-This project is a command line tool named "fq": outputs
-the frequency table of the given input.
+Command line tool "fq": outputs the frequency table of the given input.
 
     $ fq README.md	# Counted only the first 20 chars as example
     > Final frequency table
-    Symb.: 'e' 65   Freq.: 3        Pos.:  0
-    Symb.: ' ' 20   Freq.: 2        Pos.:  1
-    Symb.: '"' 22   Freq.: 2        Pos.:  2
-    Symb.: 'n' 6E   Freq.: 2        Pos.:  3
-    Symb.: 'r' 72   Freq.: 2        Pos.:  4
-    Symb.: 'u' 75   Freq.: 2        Pos.:  5
-    Symb.: 'C' 43   Freq.: 1        Pos.:  6
-    Symb.: 'F' 46   Freq.: 1        Pos.:  7
-    Symb.: 'c' 63   Freq.: 1        Pos.:  8
-    Symb.: 'o' 6F   Freq.: 1        Pos.:  9
-    Symb.: 'q' 71   Freq.: 1        Pos.:  A
-    Symb.: 't' 74   Freq.: 1        Pos.:  B
-    Symb.: 'y' 79   Freq.: 1        Pos.:  C
+	Symbol    Frequency   Pos
+	-------------------------
+	'e' 65            3     0
+	' ' 20            2     1
+	'"' 22            2     2
+	'n' 6E            2     3
+	'r' 72            2     4
+	'u' 75            2     5
+	'C' 43            1     6
+	'F' 46            1     7
+	'c' 63            1     8
+	'o' 6F            1     9
+	'q' 71            1     A
+	't' 74            1     B
+	'y' 79            1     C
+	-------------------------
     Size: 20 - Number of symbols: 13
     
     $ echo "Hello world" | fq
     > Final frequency table
-    Symb.: 'l' 6C   Freq.: 3        Pos.:  0
-    Symb.: 'o' 6F   Freq.: 2        Pos.:  1
-    Symb.: '.' 0A   Freq.: 1        Pos.:  2
-    Symb.: ' ' 20   Freq.: 1        Pos.:  3
-    Symb.: 'H' 48   Freq.: 1        Pos.:  4
-    Symb.: 'd' 64   Freq.: 1        Pos.:  5
-    Symb.: 'e' 65   Freq.: 1        Pos.:  6
-    Symb.: 'r' 72   Freq.: 1        Pos.:  7
-    Symb.: 'w' 77   Freq.: 1        Pos.:  8
+	Symbol    Frequency   Pos
+	-------------------------
+	'l' 6C            3     0
+	'o' 6F            2     1
+	'.' 0A            1     2
+	' ' 20            1     3
+	'H' 48            1     4
+	'd' 64            1     5
+	'e' 65            1     6
+	'r' 72            1     7
+	'w' 77            1     8
+	-------------------------
     Size: 12 - Number of symbols: 9
 
 The frequencies are sorted from the highest to
@@ -43,41 +48,69 @@ it iterates the file byte by byte and shows the
 frequencies each time:
 
 	$ echo "banana" | fq -v
-	Symb.: 'a' 61   Freq.: 1        Pos.:  0 *
-	Symb.: 'b' 62   Freq.: 1        Pos.:  1
+	Symbol    Frequency   Pos
+	-------------------------
+	'a' 61            1     0 *
+	'b' 62            1     1
+	-------------------------
 	Size: 2 - Number of symbols: 2
-	Symb.: 'a' 61
 	
-	Symb.: 'a' 61   Freq.: 1        Pos.:  0
-	Symb.: 'b' 62   Freq.: 1        Pos.:  1
-	Symb.: 'n' 6E   Freq.: 1        Pos.:  2 *
+	
+	Symbol    Frequency   Pos
+	-------------------------
+	'a' 61            1     0
+	'b' 62            1     1
+	'n' 6E            1     2 *
+	-------------------------
 	Size: 3 - Number of symbols: 3
-	Symb.: 'n' 6E
 	
-	Symb.: 'a' 61   Freq.: 2        Pos.:  0 *
-	Symb.: 'b' 62   Freq.: 1        Pos.:  1
-	Symb.: 'n' 6E   Freq.: 1        Pos.:  2
+	
+	Symbol    Frequency   Pos
+	-------------------------
+	'a' 61            2     0 *
+	'b' 62            1     1
+	'n' 6E            1     2
+	-------------------------
 	Size: 4 - Number of symbols: 3
-	Symb.: 'a' 61
 	
-	Symb.: 'a' 61   Freq.: 2        Pos.:  0
-	Symb.: 'n' 6E   Freq.: 2        Pos.:  1 *
-	Symb.: 'b' 62   Freq.: 1        Pos.:  2
+	
+	Symbol    Frequency   Pos
+	-------------------------
+	'a' 61            2     0
+	'n' 6E            2     1 *
+	'b' 62            1     2
+	-------------------------
 	Size: 5 - Number of symbols: 3
-	Symb.: 'n' 6E
 	
-	Symb.: 'a' 61   Freq.: 3        Pos.:  0 *
-	Symb.: 'n' 6E   Freq.: 2        Pos.:  1
-	Symb.: 'b' 62   Freq.: 1        Pos.:  2
+	
+	Symbol    Frequency   Pos
+	-------------------------
+	'a' 61            3     0 *
+	'n' 6E            2     1
+	'b' 62            1     2
+	-------------------------
 	Size: 6 - Number of symbols: 3
-	Symb.: 'a' 61
 	
-	Symb.: 'a' 61   Freq.: 3        Pos.:  0
-	Symb.: 'n' 6E   Freq.: 2        Pos.:  1
-	Symb.: '.' 0A   Freq.: 1        Pos.:  2 *
-	Symb.: 'b' 62   Freq.: 1        Pos.:  3
+	
+	Symbol    Frequency   Pos
+	-------------------------
+	'a' 61            3     0
+	'n' 6E            2     1
+	'.' 0A            1     2 *
+	'b' 62            1     3
+	-------------------------
 	Size: 7 - Number of symbols: 4
-	Symb.: '.'  A
+	
+	
+	> Final frequency table
+	Symbol    Frequency   Pos
+	-------------------------
+	'a' 61            3     0
+	'n' 6E            2     1
+	'.' 0A            1     2
+	'b' 62            1     3
+	-------------------------
+	Size: 7 - Number of symbols: 4
 
 
 Build and execute
@@ -119,7 +152,7 @@ To clean all the compiled binaries and the "Makefiles" files:
 ### Tests
 
 Tests are built with CHEAT <http://users.jyu.fi/~sapekiis/cheat/index.html>,
-an unit testing framework for C/C++ programming language.
+a unit testing framework for C/C++ programming language.
 
 To run the tests, first build the project and then execute:
 

--- a/README.md
+++ b/README.md
@@ -174,9 +174,13 @@ To clean all the compiled binaries and the "Makefiles" files:
 ### Tests
 
 Tests are built with CHEAT <https://github.com/Tuplanolla/cheat>,
-a unit testing framework for C/C++ programming language.
+a unit testing framework for C/C++ programming language, and can
+be executed with CMake CTest:
 
-To run the tests, first build the project and then execute:
+    $ make test
+
+To run the tests and see all the output in the console (specially
+if the tests fail), first build the project (`make`) and then execute:
 
     $ out/test_fq
 

--- a/src/const.h
+++ b/src/const.h
@@ -29,9 +29,11 @@
 
 #endif /* TRUE */
 
+#define OK                              0       /* Functions return 0 as success code */
 #define ERROR_MEM                       -2      /* Insufficient memory error. */
 #define ERROR_PARAM                     -3      /* Command line parametrization error. */
 #define ERROR_FILE_NOT_FOUND            -5      /* The input file is not found or can not
                                                    be opened. */
+#define ERROR_UNKNOWN                   -50     /* Unknown error */
 
 #endif /* __FQ_CONST_H */

--- a/src/const.h
+++ b/src/const.h
@@ -24,14 +24,13 @@
 
 #ifndef TRUE
 
-#define TRUE							1
-#define FALSE							0
+#define TRUE                            1
+#define FALSE                           0
 
 #endif /* TRUE */
 
-#define ERROR_MEM						-2				/* Insufficient memory error. */
-#define ERROR_PARAM						-3				/* Command line parametrization error. */
-#define ERROR_FILE_NOT_FOUND			-5				/* The input file is not found or can not
-														   be opened. */
-
+#define ERROR_MEM                       -2      /* Insufficient memory error. */
+#define ERROR_PARAM                     -3      /* Command line parametrization error. */
+#define ERROR_FILE_NOT_FOUND            -5      /* The input file is not found or can not
+                                                   be opened. */
 #endif /* __FQ_CONST_H */

--- a/src/const.h
+++ b/src/const.h
@@ -33,4 +33,5 @@
 #define ERROR_PARAM                     -3      /* Command line parametrization error. */
 #define ERROR_FILE_NOT_FOUND            -5      /* The input file is not found or can not
                                                    be opened. */
+
 #endif /* __FQ_CONST_H */

--- a/src/fq.c
+++ b/src/fq.c
@@ -43,20 +43,15 @@ fq_data *fq_data_init(void) {
 
 
 /*
- * Initialization of input/output data structures
+ * Initialization of input data structure
  * from the given file name.
- * Opens data->filename_in in "rb" mode, if it's
- * NULL, it uses stdin as data->fi file.
- * Returns `0` if no errors, otherwise an error code.
+ * Open data->filename_in in "rb" mode, if it's
+ * NULL, use stdin as data->fi file.
+ * Return `0` if no errors, otherwise an error code.
  */
-int fq_data_init_resources(fq_data *data, char *filename_in)
-{
-    if (filename_in) {
-        data->filename_in = malloc(strlen(filename_in)+1);
-        strcpy(data->filename_in, filename_in);
-    }
-    /* Open the file in binary mode / read only */
+int fq_data_init_resources(fq_data *data) {
     if (data->filename_in && strcmp(data->filename_in, "-")) {
+        /* Open the file in binary mode / read only */
         data->fi = fopen(data->filename_in, "rb");
         if (!data->fi) {
             return ERROR_FILE_NOT_FOUND;
@@ -72,10 +67,9 @@ int fq_data_init_resources(fq_data *data, char *filename_in)
 /*
  * Initialization of input/output data structures
  * from the given file.
- * Returns `0` if no errors, or an error code.
+ * Return `0` if no errors, or an error code.
  */
-int fq_data_init_resources_fi(fq_data *data, FILE *fi)
-{
+int fq_data_init_resources_fi(fq_data *data, FILE *fi) {
     data->fi = fi;
     data->length_in = 0l;
     return 0;
@@ -83,7 +77,7 @@ int fq_data_init_resources_fi(fq_data *data, FILE *fi)
 
 
 /*
- * Initializes the freql struct of data
+ * Initialize the freql struct of data
  * with the first symbol available in the
  * input stream. Return a pointer
  * to the struct created.
@@ -102,8 +96,7 @@ int fq_data_init_freql(fq_data *data) {
 /*
  * Free all input/output resources of the application.
  */
-void fq_data_free_resources(fq_data *data)
-{
+void fq_data_free_resources(fq_data *data) {
     if (data->fi) fclose(data->fi);
     if (data->freql) freqlist_free(data->freql);
     free(data);
@@ -111,7 +104,7 @@ void fq_data_free_resources(fq_data *data)
 
 
 /*
- * Counts the frequencies.
+ * Count the frequencies.
  */
 int fq_count(fq_data *data) {
     if (!data->freql) {
@@ -143,11 +136,10 @@ int fq_count(fq_data *data) {
 
 
 /*
- * Prints an insufficient memory error in the stderr, and aborts
+ * Print an insufficient memory error in the stderr, and aborts
  * the program after invoking the fq_data_free_resources function.
  */
-void error_mem(void(free_resources)(fq_data*), fq_data* data)
-{
+void error_mem(void(free_resources)(fq_data*), fq_data* data) {
     if (free_resources) {
         free_resources(data);
     }

--- a/src/fq.c
+++ b/src/fq.c
@@ -131,9 +131,7 @@ int fq_count(fq_data *data) {
 		}
 		if(data->verbose) {
 			freqlist_fprintf(stdout, NULL, data->freql, pnode);
-			printf("Symb.: '%c' %2X\n\n",
-				   (symbol<0x7F && symbol>=0x20)?symbol:'.',
-				   symbol);
+			printf("\n\n");
 		}
 		data->length_in++;
 	} while (TRUE);

--- a/src/fq.c
+++ b/src/fq.c
@@ -149,6 +149,19 @@ void error_unknown_code(int error_code, char *from,
 }
 
 /*
+ * Print an error message in the stderr that the file cannot be opened, and abort
+ * the program after invoking the free_resources function.
+ */
+void error_cannot_open(int error_code, char *file_type, char *filename,
+                       void(free_resources)(fq_data*), fq_data* data) {
+    if (free_resources) {
+        free_resources(data);
+    }
+    fprintf(stderr, "Error: The %s file `%s' cannot be opened.\n", file_type, filename);
+    exit(error_code);
+}
+
+/*
  * Print error_code in the stderr, and abort
  * the program after invoking the free_resources function.
  */

--- a/src/fq.c
+++ b/src/fq.c
@@ -21,8 +21,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "fq.h"
 #include "const.h"
+#include "util.h"
+#include "fq.h"
 #include "freqlist.h"
 
 
@@ -37,6 +38,7 @@ fq_data *fq_data_init(void) {
         data->filename_in = NULL;
         data->fi = NULL;
         data->freql = NULL;
+        data->length_in = 0l;
     }
     return data;
 }
@@ -59,7 +61,6 @@ int fq_data_init_resources(fq_data *data) {
     } else {
         data->fi = stdin;
     }
-    data->length_in = 0l;
     return 0;
 }
 
@@ -110,7 +111,7 @@ void fq_data_free_resources(fq_data *data) {
 int fq_count(fq_data *data) {
     if (!data->freql) {
         if (!fq_data_init_freql(data)) {
-            error_mem(fq_data_free_resources, data);
+            error_mem((void*)fq_data_free_resources, data);
         }
     }
     node_freqlist *pnode = NULL;
@@ -133,54 +134,4 @@ int fq_count(fq_data *data) {
         freqlist_sort(data->freql);
     }
     return 0;
-}
-
-/*
- * Print an error message with error_code and from string in the stderr, and abort
- * the program after invoking the free_resources function.
- */
-void error_unknown_code(int error_code, char *from,
-                        void(free_resources)(fq_data*), fq_data* data) {
-    if (free_resources) {
-        free_resources(data);
-    }
-    fprintf(stderr, "Error: unknown error code [%d] from `%s'.\n", error_code, from);
-    exit(ERROR_UNKNOWN);
-}
-
-/*
- * Print an error message in the stderr that the file cannot be opened, and abort
- * the program after invoking the free_resources function.
- */
-void error_cannot_open(int error_code, char *file_type, char *filename,
-                       void(free_resources)(fq_data*), fq_data* data) {
-    if (free_resources) {
-        free_resources(data);
-    }
-    fprintf(stderr, "Error: The %s file `%s' cannot be opened.\n", file_type, filename);
-    exit(error_code);
-}
-
-/*
- * Print error_code in the stderr, and abort
- * the program after invoking the free_resources function.
- */
-void fatal(int error_code,
-           char *error_msg,
-           void(free_resources)(fq_data*), fq_data* data) {
-    if (free_resources) {
-        free_resources(data);
-    }
-    fprintf(stderr, error_msg);
-    exit(error_code);
-}
-
-
-/*
- * Print an insufficient memory error in the stderr, and abort
- * the program after invoking the free_resources function.
- */
-void error_mem(void(free_resources)(fq_data*), fq_data* data) {
-    fatal(ERROR_MEM, "Error: Insufficient memory.\n",
-          free_resources, data);
 }

--- a/src/fq.c
+++ b/src/fq.c
@@ -56,7 +56,7 @@ int fq_data_init_resources(fq_data *data, char *filename_in)
 		strcpy(data->filename_in, filename_in);
 	}
 	/* Open the file in binary mode / read only */
-	if (data->filename_in) {
+	if (data->filename_in && strcmp(data->filename_in, "-")) {
 		data->fi = fopen(data->filename_in, "rb");
 		if (!data->fi) {
 			return ERROR_FILE_NOT_FOUND;

--- a/src/fq.c
+++ b/src/fq.c
@@ -67,12 +67,10 @@ int fq_data_init_resources(fq_data *data) {
 /*
  * Initialization of input/output data structures
  * from the given file.
- * Return `0` if no errors, or an error code.
  */
-int fq_data_init_resources_fi(fq_data *data, FILE *fi) {
+void fq_data_init_resources_fi(fq_data *data, FILE *fi) {
     data->fi = fi;
     data->length_in = 0l;
-    return 0;
 }
 
 

--- a/src/fq.c
+++ b/src/fq.c
@@ -80,7 +80,7 @@ void fq_data_init_resources_fi(fq_data *data, FILE *fi) {
  * input stream. Return a pointer
  * to the struct created.
  */
-int fq_data_init_freql(fq_data *data) {
+freqlist *fq_data_init_freql(fq_data *data) {
     int first_symb = fgetc(data->fi);
     if (first_symb != EOF) {
         data->length_in++;

--- a/src/fq.c
+++ b/src/fq.c
@@ -31,14 +31,14 @@
  * default values.
  */
 fq_data *fq_data_init(void) {
-	fq_data* data = (fq_data*) malloc(sizeof(fq_data));
-	if (data) {
-		data->verbose = FALSE;
-		data->filename_in = NULL;
-		data->fi = NULL;
-		data->freql = NULL;
-	}
-	return data;
+    fq_data* data = (fq_data*) malloc(sizeof(fq_data));
+    if (data) {
+        data->verbose = FALSE;
+        data->filename_in = NULL;
+        data->fi = NULL;
+        data->freql = NULL;
+    }
+    return data;
 }
 
 
@@ -51,21 +51,21 @@ fq_data *fq_data_init(void) {
  */
 int fq_data_init_resources(fq_data *data, char *filename_in)
 {
-	if (filename_in) {
-		data->filename_in = malloc(strlen(filename_in)+1);
-		strcpy(data->filename_in, filename_in);
-	}
-	/* Open the file in binary mode / read only */
-	if (data->filename_in && strcmp(data->filename_in, "-")) {
-		data->fi = fopen(data->filename_in, "rb");
-		if (!data->fi) {
-			return ERROR_FILE_NOT_FOUND;
-		}
-	} else {
-		data->fi = stdin;
-	}
-	data->length_in = 0l;
-	return 0;
+    if (filename_in) {
+        data->filename_in = malloc(strlen(filename_in)+1);
+        strcpy(data->filename_in, filename_in);
+    }
+    /* Open the file in binary mode / read only */
+    if (data->filename_in && strcmp(data->filename_in, "-")) {
+        data->fi = fopen(data->filename_in, "rb");
+        if (!data->fi) {
+            return ERROR_FILE_NOT_FOUND;
+        }
+    } else {
+        data->fi = stdin;
+    }
+    data->length_in = 0l;
+    return 0;
 }
 
 
@@ -76,9 +76,9 @@ int fq_data_init_resources(fq_data *data, char *filename_in)
  */
 int fq_data_init_resources_fi(fq_data *data, FILE *fi)
 {
-	data->fi = fi;
-	data->length_in = 0l;
-	return 0;
+    data->fi = fi;
+    data->length_in = 0l;
+    return 0;
 }
 
 
@@ -89,13 +89,13 @@ int fq_data_init_resources_fi(fq_data *data, FILE *fi)
  * to the struct created.
  */
 int fq_data_init_freql(fq_data *data) {
-	int first_symb = fgetc(data->fi);
-	if (first_symb != EOF) {
-		data->length_in++;
-		data->freql = freqlist_create(first_symb);
-	}
-	data->freql->autosort = data->verbose;
-	return data->freql;
+    int first_symb = fgetc(data->fi);
+    if (first_symb != EOF) {
+        data->length_in++;
+        data->freql = freqlist_create(first_symb);
+    }
+    data->freql->autosort = data->verbose;
+    return data->freql;
 }
 
 
@@ -104,9 +104,9 @@ int fq_data_init_freql(fq_data *data) {
  */
 void fq_data_free_resources(fq_data *data)
 {
-	if (data->fi) fclose(data->fi);
-	if (data->freql) freqlist_free(data->freql);
-	free(data);
+    if (data->fi) fclose(data->fi);
+    if (data->freql) freqlist_free(data->freql);
+    free(data);
 }
 
 
@@ -114,31 +114,31 @@ void fq_data_free_resources(fq_data *data)
  * Counts the frequencies.
  */
 int fq_count(fq_data *data) {
-	if (!data->freql) {
-		if (!fq_data_init_freql(data)) {
-			error_mem(fq_data_free_resources, data);
-		}
-	}
-	node_freqlist *pnode = NULL;
-	do {
-		unsigned char symbol = fgetc(data->fi);	// A buffer is not used due
-		if( feof(data->fi) ) {					// that any modern OS
-			break ;								// use one when we use
-		}										// the libc library for I/O
-		pnode = freqlist_add(data->freql, symbol);
-		if (!pnode) {
-			return ERROR_MEM;
-		}
-		if(data->verbose) {
-			freqlist_fprintf(stdout, NULL, data->freql, pnode);
-			printf("\n\n");
-		}
-		data->length_in++;
-	} while (TRUE);
-	if (!data->freql->autosort) {
-		freqlist_sort(data->freql);
-	}
-	return 0;
+    if (!data->freql) {
+        if (!fq_data_init_freql(data)) {
+            error_mem(fq_data_free_resources, data);
+        }
+    }
+    node_freqlist *pnode = NULL;
+    do {
+        unsigned char symbol = fgetc(data->fi);   // A buffer is not used due
+        if( feof(data->fi) ) {                    // that any modern OS
+            break ;                               // use one when we use
+        }                                         // the libc library for I/O
+        pnode = freqlist_add(data->freql, symbol);
+        if (!pnode) {
+            return ERROR_MEM;
+        }
+        if(data->verbose) {
+            freqlist_fprintf(stdout, NULL, data->freql, pnode);
+            printf("\n\n");
+        }
+        data->length_in++;
+    } while (TRUE);
+    if (!data->freql->autosort) {
+        freqlist_sort(data->freql);
+    }
+    return 0;
 }
 
 
@@ -148,9 +148,9 @@ int fq_count(fq_data *data) {
  */
 void error_mem(void(free_resources)(fq_data*), fq_data* data)
 {
-	if (free_resources) {
-		free_resources(data);
-	}
-	fprintf(stderr, "Error: Insufficient memory.\n");
-	exit(ERROR_MEM);
+    if (free_resources) {
+        free_resources(data);
+    }
+    fprintf(stderr, "Error: Insufficient memory.\n");
+    exit(ERROR_MEM);
 }

--- a/src/fq.c
+++ b/src/fq.c
@@ -95,7 +95,10 @@ int fq_data_init_freql(fq_data *data) {
  * Free all input/output resources of the application.
  */
 void fq_data_free_resources(fq_data *data) {
-    if (data->fi) fclose(data->fi);
+    if (data->fi) {
+        fflush(data->fi);
+        if (data->fi != stdin) fclose(data->fi);
+    }
     if (data->freql) freqlist_free(data->freql);
     free(data);
 }

--- a/src/fq.c
+++ b/src/fq.c
@@ -47,7 +47,7 @@ fq_data *fq_data_init(void) {
  * from the given file name.
  * Open data->filename_in in "rb" mode, if it's
  * NULL, use stdin as data->fi file.
- * Return `0` if no errors, otherwise an error code.
+ * Return 0 if no errors, otherwise an error code.
  */
 int fq_data_init_resources(fq_data *data) {
     if (data->filename_in && strcmp(data->filename_in, "-")) {
@@ -135,15 +135,39 @@ int fq_count(fq_data *data) {
     return 0;
 }
 
-
 /*
- * Print an insufficient memory error in the stderr, and aborts
- * the program after invoking the fq_data_free_resources function.
+ * Print an error message with error_code and from string in the stderr, and abort
+ * the program after invoking the free_resources function.
  */
-void error_mem(void(free_resources)(fq_data*), fq_data* data) {
+void error_unknown_code(int error_code, char *from,
+                        void(free_resources)(fq_data*), fq_data* data) {
     if (free_resources) {
         free_resources(data);
     }
-    fprintf(stderr, "Error: Insufficient memory.\n");
-    exit(ERROR_MEM);
+    fprintf(stderr, "Error: unknown error code [%d] from `%s'.\n", error_code, from);
+    exit(ERROR_UNKNOWN);
+}
+
+/*
+ * Print error_code in the stderr, and abort
+ * the program after invoking the free_resources function.
+ */
+void fatal(int error_code,
+           char *error_msg,
+           void(free_resources)(fq_data*), fq_data* data) {
+    if (free_resources) {
+        free_resources(data);
+    }
+    fprintf(stderr, error_msg);
+    exit(error_code);
+}
+
+
+/*
+ * Print an insufficient memory error in the stderr, and abort
+ * the program after invoking the free_resources function.
+ */
+void error_mem(void(free_resources)(fq_data*), fq_data* data) {
+    fatal(ERROR_MEM, "Error: Insufficient memory.\n",
+          free_resources, data);
 }

--- a/src/fq.c
+++ b/src/fq.c
@@ -76,18 +76,13 @@ void fq_data_init_resources_fi(fq_data *data, FILE *fi) {
 
 
 /*
- * Initialize the freql struct of data
- * with the first symbol available in the
- * input stream. Return a pointer
- * to the struct created.
+ * Initialize the freql struct of data.
  */
 freqlist *fq_data_init_freql(fq_data *data) {
-    int first_symb = fgetc(data->fi);
-    if (first_symb != EOF) {
-        data->length_in++;
-        data->freql = freqlist_create(first_symb);
+    data->freql = freqlist_create();
+    if (data->freql) {
+        data->freql->autosort = data->verbose;
     }
-    data->freql->autosort = data->verbose;
     return data->freql;
 }
 
@@ -114,21 +109,20 @@ int fq_count(fq_data *data) {
             error_mem((void*)fq_data_free_resources, data);
         }
     }
-    node_freqlist *pnode = NULL;
     do {
         unsigned char symbol = fgetc(data->fi);   // A buffer is not used due
         if( feof(data->fi) ) {                    // that any modern OS
-            break ;                               // use one when we use
-        }                                         // the libc library for I/O
-        pnode = freqlist_add(data->freql, symbol);
+            break ;                               // has one provided by
+        }                                         // the libc library when I/O
+        node_freqlist *pnode = freqlist_add(data->freql, symbol);
         if (!pnode) {
             return ERROR_MEM;
         }
+        data->length_in++;
         if(data->verbose) {
             freqlist_fprintf(stdout, NULL, data->freql, pnode);
             printf("\n\n");
         }
-        data->length_in++;
     } while (TRUE);
     if (!data->freql->autosort) {
         freqlist_sort(data->freql);

--- a/src/fq.h
+++ b/src/fq.h
@@ -52,7 +52,7 @@ fq_data* fq_data_init(void);
  * from the given file name.
  * Open data->filename_in in "rb" mode, if it's
  * NULL, use stdin as data->fi file.
- * Return `0` if no errors, otherwise an error code.
+ * Return 0 if no errors, otherwise an error code.
  */
 int fq_data_init_resources(fq_data *data);
 
@@ -84,10 +84,25 @@ void fq_data_free_resources(fq_data *data);
  */
 int fq_count(fq_data *data);
 
+/*
+ * Print an error message with error_code and from string in the stderr, and abort
+ * the program after invoking the free_resources function.
+ */
+void error_unknown_code(int error_code, char *from,
+                        void(free_resources)(fq_data*), fq_data* data);
 
 /*
- * Print an insufficient memory error in the stderr, and aborts
- * the program after invoking the fq_data_free_resources function.
+ * Print error_code in the stderr, and abort
+ * the program after invoking the free_resources function.
+ */
+void fatal(int error_code,
+           char *error_msg,
+           void(free_resources)(fq_data*), fq_data* data);
+
+
+/*
+ * Print an insufficient memory error in the stderr, and abort
+ * the program after invoking the free_resources function.
  */
 void error_mem(void(free_resources)(fq_data*), fq_data* data);
 

--- a/src/fq.h
+++ b/src/fq.h
@@ -84,34 +84,5 @@ void fq_data_free_resources(fq_data *data);
  */
 int fq_count(fq_data *data);
 
-/*
- * Print an error message with error_code and from string in the stderr, and abort
- * the program after invoking the free_resources function.
- */
-void error_unknown_code(int error_code, char *from,
-                        void(free_resources)(fq_data*), fq_data* data);
-
-/*
- * Print an error message in the stderr that the file cannot be opened, and abort
- * the program after invoking the free_resources function.
- */
-void error_cannot_open(int error_code, char *file_type, char *filename,
-                       void(free_resources)(fq_data*), fq_data* data);
-
-/*
- * Print error_code in the stderr, and abort
- * the program after invoking the free_resources function.
- */
-void fatal(int error_code,
-           char *error_msg,
-           void(free_resources)(fq_data*), fq_data* data);
-
-
-/*
- * Print an insufficient memory error in the stderr, and abort
- * the program after invoking the free_resources function.
- */
-void error_mem(void(free_resources)(fq_data*), fq_data* data);
-
 
 #endif /* __FQ_H */

--- a/src/fq.h
+++ b/src/fq.h
@@ -70,7 +70,7 @@ void fq_data_init_resources_fi(fq_data *data, FILE *fi);
  * input stream. Return a pointer
  * to the struct created.
  */
-int fq_data_init_freql(fq_data *data);
+freqlist *fq_data_init_freql(fq_data *data);
 
 
 /*

--- a/src/fq.h
+++ b/src/fq.h
@@ -65,10 +65,7 @@ void fq_data_init_resources_fi(fq_data *data, FILE *fi);
 
 
 /*
- * Initialize the freql struct of data
- * with the first symbol available in the
- * input stream. Return a pointer
- * to the struct created.
+ * Initialize the freql struct of data.
  */
 freqlist *fq_data_init_freql(fq_data *data);
 

--- a/src/fq.h
+++ b/src/fq.h
@@ -60,9 +60,8 @@ int fq_data_init_resources(fq_data *data);
 /*
  * Initialization of input/output data structures
  * from the given file.
- * Return `0` if no errors, or an error code.
  */
-int fq_data_init_resources_fi(fq_data *data, FILE *fi);
+void fq_data_init_resources_fi(fq_data *data, FILE *fi);
 
 
 /*

--- a/src/fq.h
+++ b/src/fq.h
@@ -26,7 +26,7 @@
 
 
 /*
- * Contains the main information about
+ * Contain the main information about
  * the encoding process: input file, frequency list, etc.
  */
 typedef struct _fq_data {
@@ -48,24 +48,25 @@ fq_data* fq_data_init(void);
 
 
 /*
- * Initialization of input data structures.
- * Opens data->filename_in in "rb" mode, if it's
- * NULL, it uses stdin as data->fi file.
- * Returns `0` if no errors, or an error code.
+ * Initialization of input data structure
+ * from the given file name.
+ * Open data->filename_in in "rb" mode, if it's
+ * NULL, use stdin as data->fi file.
+ * Return `0` if no errors, otherwise an error code.
  */
-int fq_data_init_resources(fq_data *data, char *filename_in);
+int fq_data_init_resources(fq_data *data);
 
 
 /*
  * Initialization of input/output data structures
  * from the given file.
- * Returns `0` if no errors, or an error code.
+ * Return `0` if no errors, or an error code.
  */
 int fq_data_init_resources_fi(fq_data *data, FILE *fi);
 
 
 /*
- * Initializes the freql struct of data
+ * Initialize the freql struct of data
  * with the first symbol available in the
  * input stream. Return a pointer
  * to the struct created.
@@ -80,13 +81,13 @@ void fq_data_free_resources(fq_data *data);
 
 
 /*
- * Counts the frequencies.
+ * Count the frequencies.
  */
 int fq_count(fq_data *data);
 
 
 /*
- * Prints an insufficient memory error in the stderr, and aborts
+ * Print an insufficient memory error in the stderr, and aborts
  * the program after invoking the fq_data_free_resources function.
  */
 void error_mem(void(free_resources)(fq_data*), fq_data* data);

--- a/src/fq.h
+++ b/src/fq.h
@@ -30,11 +30,11 @@
  * the encoding process: input file, frequency list, etc.
  */
 typedef struct _fq_data {
-	char *filename_in;			/* Input file name */
-	FILE *fi;					/* Input file manager */
-	unsigned long length_in;	/* File size in bytes */
-	freqlist *freql;			/* Frequency list of characters */
-	int verbose;				/* If TRUE the verbose mode is activated */
+    char *filename_in;          /* Input file name */
+    FILE *fi;                   /* Input file manager */
+    unsigned long length_in;    /* File size in bytes */
+    freqlist *freql;            /* Frequency list of characters */
+    int verbose;                /* If TRUE the verbose mode is activated */
 } fq_data;
 
 

--- a/src/fq.h
+++ b/src/fq.h
@@ -92,6 +92,13 @@ void error_unknown_code(int error_code, char *from,
                         void(free_resources)(fq_data*), fq_data* data);
 
 /*
+ * Print an error message in the stderr that the file cannot be opened, and abort
+ * the program after invoking the free_resources function.
+ */
+void error_cannot_open(int error_code, char *file_type, char *filename,
+                       void(free_resources)(fq_data*), fq_data* data);
+
+/*
  * Print error_code in the stderr, and abort
  * the program after invoking the free_resources function.
  */

--- a/src/freqlist.c
+++ b/src/freqlist.c
@@ -38,7 +38,7 @@ void freqlist_fprintf(FILE *f, const char *title,
     char *mark = "";
     char markup[16];
     if (pnode) {
-        if (freql->freqs[pnode->symb]==1) {
+        if (pnode->freq==1) {
             mark = " *";
         } else if (pnode->debug_last_jump == 0) {
             mark = " <";
@@ -69,8 +69,6 @@ freqlist* freqlist_create() {
     freqlist *l = (freqlist *)malloc(sizeof(freqlist));
     if (l) {
         l->list = NULL;
-        for (int i=0; i<256; i++)
-            l->freqs[i] = 0;
         l->length = 0;
         l->size = 0L;
         l->autosort = FALSE;
@@ -149,7 +147,6 @@ node_freqlist *freqlist_add(freqlist *l, unsigned char c) {
        and call the function that will promote the symbol. */
     if (pnode1 && c==pnode1->symb) {
         pnode1->freq++;
-        l->freqs[c]++;
         l->size++;
         if (l->autosort) {
             _freqlist_promote(l, pnode1);
@@ -162,7 +159,6 @@ node_freqlist *freqlist_add(freqlist *l, unsigned char c) {
        promotion algorithm. */
     pnode1 = freqlist_create_node(c, 0, 1l);
     if (pnode1) {
-        l->freqs[c]=1;
         l->size++;
         l->length++;
         if (pnode_prev) {

--- a/src/freqlist.c
+++ b/src/freqlist.c
@@ -24,16 +24,15 @@
 
 
 /*
- * Prints the list of frequencies.
+ * Print the list of frequencies.
  * @f: the output stream, eg. the stdout.
- * @title: prints this message before the list (optional).
+ * @title: print this message before the list (optional).
  * @freql: the frequency list.
  * @pnode: if not null the symbol is highlighted in
  *         the list (optional).
  */
 void freqlist_fprintf(FILE *f, const char *title,
-                      const freqlist *freql, node_freqlist *pnode)
-{
+                      const freqlist *freql, node_freqlist *pnode) {
     if (title)
         fprintf(f, title);
     char *mark = "";
@@ -64,11 +63,10 @@ void freqlist_fprintf(FILE *f, const char *title,
 
 
 /*
- * Creates a list, and initializes the first node with the passed value.
- * Returns the list created.
+ * Create a list, and initialize the first node with the passed value.
+ * Return the list created.
  */
-freqlist* freqlist_create(unsigned char c)
-{
+freqlist* freqlist_create(unsigned char c) {
     freqlist *l = (freqlist *)malloc(sizeof(freqlist));
     if (l) {
         l->list=(node_freqlist *)malloc(sizeof(node_freqlist));
@@ -90,10 +88,9 @@ freqlist* freqlist_create(unsigned char c)
 }
 
 /*
- * Frees the memory of the list.
+ * Free the memory of the list.
  */
-void freqlist_free(freqlist* l)
-{
+void freqlist_free(freqlist* l) {
     node_freqlist *pnode;
     pnode=l->list;
     while (pnode->next)
@@ -108,11 +105,10 @@ void freqlist_free(freqlist* l)
 
 
 /*
- * Returns the node with the symbol 'c', or return NULL if not
+ * Return the node with the symbol 'c', or return NULL if not
  * in the list.
  */
-node_freqlist *freqlist_find(const freqlist *l, unsigned char c)
-{
+node_freqlist *freqlist_find(const freqlist *l, unsigned char c) {
     /* TODO Check if the node exist with l.freqs[c] > 0
             to be more efficient */
     node_freqlist *pnode = l->list;
@@ -124,13 +120,12 @@ node_freqlist *freqlist_find(const freqlist *l, unsigned char c)
 
 
 /*
- * Increases the frequency of the symbol 'c' in +1,
- * and rearranges if necessary. If the symbol is not present
- * in the list, it adds them, an sets the frequency of the node in 1.
- * Returns the node with the symbol.
+ * Increase the frequency of the symbol 'c' in +1,
+ * and rearrange if necessary. If the symbol is not present
+ * in the list, add them, an set the frequency of the node in 1.
+ * Return the node with the symbol.
  */
-node_freqlist *freqlist_add(freqlist *l, unsigned char c)
-{
+node_freqlist *freqlist_add(freqlist *l, unsigned char c) {
     node_freqlist *pnode1, *pnode_prev;
 
     /* This function promotes the position of the symbol in the list
@@ -176,10 +171,9 @@ node_freqlist *freqlist_add(freqlist *l, unsigned char c)
 }
 
 
-/* Promotes the position of the symbol in the list
+/* Promote the position of the symbol in the list
    (called after its frequency was increased, or after being created. */
-void _freqlist_promote(freqlist *l, node_freqlist *pnode)
-{
+void _freqlist_promote(freqlist *l, node_freqlist *pnode) {
     unsigned char i;
     int steps = 0;      /* num of elements walked until reached new pos */
 
@@ -242,8 +236,7 @@ void _freqlist_promote(freqlist *l, node_freqlist *pnode)
 /* This function dis-promotes the position of the symbol in the list
    after decrease its frequency.
    Return 1 if element if removed from the list, otherwise 0 */
-int _freqlist_dispromote(freqlist *l, node_freqlist *pnode)
-{
+int _freqlist_dispromote(freqlist *l, node_freqlist *pnode) {
     node_freqlist *pnode1, *pnode2, *pnode3=NULL;
 
     /* If the node has freq=0 is removed from the list */
@@ -342,7 +335,7 @@ int _freqlist_dispromote(freqlist *l, node_freqlist *pnode)
  * If pnode0 is NULL, then l->list = pnode (first element
  * in the list).
  *
- * Returns 1 if the element were swapped, else 0.
+ * Return 1 if the element were swapped, else 0.
  */
 int _freqlist_swap_with_prev(freqlist *l, node_freqlist * pnode) {
     if (pnode->prev) {
@@ -371,8 +364,8 @@ int _freqlist_swap_with_prev(freqlist *l, node_freqlist * pnode) {
 
 
 /*
- * Sorts the frequencies in case aren't sort.
- * Returns the number of swaps made.
+ * Sort the frequencies in case aren't sort.
+ * Return the number of swaps made.
  */
 int freqlist_sort(freqlist *l) {
     int swaps = 0;
@@ -395,11 +388,10 @@ int freqlist_sort(freqlist *l) {
 
 
 /*
- * Compares by frequency of the node,
- * or symbol if the frequencies are equals.
+ * Compare by frequency of the node,
+ * or symbol if the frequencies are equal.
  */
-int node_cmp(const node_freqlist *pnode1, const node_freqlist *pnode2)
-{
+int node_cmp(const node_freqlist *pnode1, const node_freqlist *pnode2) {
     if ( pnode1->freq > pnode2->freq
          || (pnode1->freq == pnode2->freq && pnode1->symb < pnode2->symb) ) {
         return 1;

--- a/src/freqlist.c
+++ b/src/freqlist.c
@@ -34,32 +34,32 @@
 void freqlist_fprintf(FILE *f, const char *title,
                       const freqlist *freql, node_freqlist *pnode)
 {
-	if (title)
-		fprintf(f, title);
-	char *mark = "";
-	char markup[16];
-	if (pnode) {
-		if (freql->freqs[pnode->symb]==1) {
-    		mark = " *";
-		} else if (pnode->debug_last_jump == 0) {
-			mark = " <";
-		} else {    // +1..
-			sprintf(markup, " ^ (%+d)", pnode->debug_last_jump);
-			mark = markup;
-		}
-	}
-	fprintf(f, "Symbol    Frequency   Pos\n");
-	fprintf(f, "-------------------------\n");
-	for (node_freqlist *pnode_i=freql->list; pnode_i; pnode_i=pnode_i->next)
-		fprintf(f, "'%c' %02X    %9lu    %2X%s\n",
-				(pnode_i->symb < 0x7F && pnode_i->symb >= 0x20) ? pnode_i->symb : '.',
-				pnode_i->symb,
-				pnode_i->freq,
-				pnode_i->pos,
+    if (title)
+        fprintf(f, title);
+    char *mark = "";
+    char markup[16];
+    if (pnode) {
+        if (freql->freqs[pnode->symb]==1) {
+            mark = " *";
+        } else if (pnode->debug_last_jump == 0) {
+            mark = " <";
+        } else {    // +1..
+            sprintf(markup, " ^ (%+d)", pnode->debug_last_jump);
+            mark = markup;
+        }
+    }
+    fprintf(f, "Symbol    Frequency   Pos\n");
+    fprintf(f, "-------------------------\n");
+    for (node_freqlist *pnode_i=freql->list; pnode_i; pnode_i=pnode_i->next)
+        fprintf(f, "'%c' %02X    %9lu    %2X%s\n",
+                (pnode_i->symb < 0x7F && pnode_i->symb >= 0x20) ? pnode_i->symb : '.',
+                pnode_i->symb,
+                pnode_i->freq,
+                pnode_i->pos,
                 pnode && pnode == pnode_i ? mark : "");
-	fprintf(f, "-------------------------\n");
-	fprintf(f, "Size: %lu - Number of symbols: %d\n",
-			freql->size, freql->length);
+    fprintf(f, "-------------------------\n");
+    fprintf(f, "Size: %lu - Number of symbols: %d\n",
+            freql->size, freql->length);
 }
 
 
@@ -69,24 +69,24 @@ void freqlist_fprintf(FILE *f, const char *title,
  */
 freqlist* freqlist_create(unsigned char c)
 {
-	freqlist *l = (freqlist *)malloc(sizeof(freqlist));
-	if (l) {
-		l->list=(node_freqlist *)malloc(sizeof(node_freqlist));
-		if (l->list) {
-			l->list->symb=c;
-			l->list->pos=(unsigned char)0;
-			l->list->freq=1;
-			l->list->next=l->list->prev=NULL;
-			l->list->debug_last_jump = 0;
-		}
-		for (int i=0; i<256; i++)
-			l->freqs[i]=0;
-		l->freqs[c]=1;
-		l->length=1;
-		l->size=1L;
-		l->autosort = FALSE;
-	}
-	return l;
+    freqlist *l = (freqlist *)malloc(sizeof(freqlist));
+    if (l) {
+        l->list=(node_freqlist *)malloc(sizeof(node_freqlist));
+        if (l->list) {
+            l->list->symb=c;
+            l->list->pos=(unsigned char)0;
+            l->list->freq=1;
+            l->list->next=l->list->prev=NULL;
+            l->list->debug_last_jump = 0;
+        }
+        for (int i=0; i<256; i++)
+            l->freqs[i]=0;
+        l->freqs[c]=1;
+        l->length=1;
+        l->size=1L;
+        l->autosort = FALSE;
+    }
+    return l;
 }
 
 /*
@@ -94,16 +94,16 @@ freqlist* freqlist_create(unsigned char c)
  */
 void freqlist_free(freqlist* l)
 {
-	node_freqlist *pnode;
-	pnode=l->list;
-	while (pnode->next)
-		pnode=pnode->next;
-	while (pnode->prev) {
-		pnode=pnode->prev;
-		free(pnode->next);
-	}
-	free(pnode);
-	free(l);
+    node_freqlist *pnode;
+    pnode=l->list;
+    while (pnode->next)
+        pnode=pnode->next;
+    while (pnode->prev) {
+        pnode=pnode->prev;
+        free(pnode->next);
+    }
+    free(pnode);
+    free(l);
 }
 
 
@@ -113,12 +113,12 @@ void freqlist_free(freqlist* l)
  */
 node_freqlist *freqlist_find(const freqlist *l, unsigned char c)
 {
-	/* TODO Check if the node exist with l.freqs[c] > 0
-	        to be more efficient */
-	node_freqlist *pnode = l->list;
-	while (pnode && c!=pnode->symb) pnode=pnode->next;
-	if (pnode && c==pnode->symb) return pnode;
-	return NULL;
+    /* TODO Check if the node exist with l.freqs[c] > 0
+            to be more efficient */
+    node_freqlist *pnode = l->list;
+    while (pnode && c!=pnode->symb) pnode=pnode->next;
+    if (pnode && c==pnode->symb) return pnode;
+    return NULL;
 }
 
 
@@ -131,48 +131,48 @@ node_freqlist *freqlist_find(const freqlist *l, unsigned char c)
  */
 node_freqlist *freqlist_add(freqlist *l, unsigned char c)
 {
-	node_freqlist *pnode1, *pnode_prev;
+    node_freqlist *pnode1, *pnode_prev;
 
-	/* This function promotes the position of the symbol in the list
-	   after increase its frequency, or being created. */
-	void _freqlist_promote(freqlist *l, node_freqlist *pnode);
+    /* This function promotes the position of the symbol in the list
+       after increase its frequency, or being created. */
+    void _freqlist_promote(freqlist *l, node_freqlist *pnode);
 
-	pnode1=l->list;
-	while (pnode1 && c!=pnode1->symb) {
-		pnode_prev=pnode1;
-		pnode1=pnode1->next;
-	}
+    pnode1=l->list;
+    while (pnode1 && c!=pnode1->symb) {
+        pnode_prev=pnode1;
+        pnode1=pnode1->next;
+    }
 
-	/* After found the symbol in the list, increase its frequency
-	   and call the function that will promote the symbol. */
-	if (pnode1 && c==pnode1->symb) {
-		pnode1->freq++;
-		l->freqs[c]++;
-		l->size++;
-		if (l->autosort) {
-			_freqlist_promote(l, pnode1);
-		}
-		return pnode1;
-	}
+    /* After found the symbol in the list, increase its frequency
+       and call the function that will promote the symbol. */
+    if (pnode1 && c==pnode1->symb) {
+        pnode1->freq++;
+        l->freqs[c]++;
+        l->size++;
+        if (l->autosort) {
+            _freqlist_promote(l, pnode1);
+        }
+        return pnode1;
+    }
 
-	/* If the element doesn't exist, it's added to the end of the list,
-	   with frequency=1, and is promoted in the list with the same
-	   promotion algorithm. */
-	pnode1=(node_freqlist *)malloc(sizeof(node_freqlist));
-	if (pnode1) {
-		l->freqs[c]=1;
-		l->size++;
-		l->length++;
-		pnode1->symb=c;
-		pnode1->pos=pnode_prev->pos + 1;
-		pnode1->freq=1;
-		pnode1->prev=pnode_prev;
-		pnode1->next=NULL;
-		pnode1->debug_last_jump=0;
-		pnode_prev->next=pnode1;
-		_freqlist_promote(l, pnode1);
-	}
-	return pnode1;
+    /* If the element doesn't exist, it's added to the end of the list,
+       with frequency=1, and is promoted in the list with the same
+       promotion algorithm. */
+    pnode1=(node_freqlist *)malloc(sizeof(node_freqlist));
+    if (pnode1) {
+        l->freqs[c]=1;
+        l->size++;
+        l->length++;
+        pnode1->symb=c;
+        pnode1->pos=pnode_prev->pos + 1;
+        pnode1->freq=1;
+        pnode1->prev=pnode_prev;
+        pnode1->next=NULL;
+        pnode1->debug_last_jump=0;
+        pnode_prev->next=pnode1;
+        _freqlist_promote(l, pnode1);
+    }
+    return pnode1;
 }
 
 
@@ -180,62 +180,62 @@ node_freqlist *freqlist_add(freqlist *l, unsigned char c)
    (called after its frequency was increased, or after being created. */
 void _freqlist_promote(freqlist *l, node_freqlist *pnode)
 {
-	unsigned char i;
-	int steps = 0;	  /* num of elements walked until reached new pos */
+    unsigned char i;
+    int steps = 0;      /* num of elements walked until reached new pos */
 
-	node_freqlist *pnode_prev=pnode->prev,
-	              *pnode_next;
+    node_freqlist *pnode_prev=pnode->prev,
+                  *pnode_next;
 
-	/* While exist a prev node with less frequency than pnode
-	   or have the same frequency but a lower ASCII code ... */
-	while (pnode_prev && node_cmp(pnode, pnode_prev) > 0 ) {
-		pnode_prev=pnode_prev->prev;
-		steps++;
-	}
-	pnode->debug_last_jump = steps;
+    /* While exist a prev node with less frequency than pnode
+       or have the same frequency but a lower ASCII code ... */
+    while (pnode_prev && node_cmp(pnode, pnode_prev) > 0 ) {
+        pnode_prev=pnode_prev->prev;
+        steps++;
+    }
+    pnode->debug_last_jump = steps;
 
-	if (pnode_prev && pnode_prev != pnode->prev) {
-		/* Previous and next of pnode point together */
-		(pnode->prev)->next=pnode->next;
-		if (pnode->next)
-			(pnode->next)->prev=pnode->prev;
-		/* pnode points at its new prev and next */
-		pnode->prev=pnode_prev;
-		pnode_next=pnode->next;
-		pnode->next=pnode_prev->next;
-		/* The pnode new and prev point to pnode */
-		pnode_prev->next=pnode;
-		(pnode->next)->prev=pnode;
+    if (pnode_prev && pnode_prev != pnode->prev) {
+        /* Previous and next of pnode point together */
+        (pnode->prev)->next=pnode->next;
+        if (pnode->next)
+            (pnode->next)->prev=pnode->prev;
+        /* pnode points at its new prev and next */
+        pnode->prev=pnode_prev;
+        pnode_next=pnode->next;
+        pnode->next=pnode_prev->next;
+        /* The pnode new and prev point to pnode */
+        pnode_prev->next=pnode;
+        (pnode->next)->prev=pnode;
 
-		/* pnode is assigned to the position it has its next */
-		pnode->pos=(pnode->next)->pos;
-		/* Increase in +1 the pos variable of all nodes after pnode */
-		pnode_prev=pnode;
-		while (pnode_prev->next && pnode_prev->next != pnode_next) {
-			pnode_prev=pnode_prev->next;
-			pnode_prev->pos++;
-		}
-		return;
-	}
+        /* pnode is assigned to the position it has its next */
+        pnode->pos=(pnode->next)->pos;
+        /* Increase in +1 the pos variable of all nodes after pnode */
+        pnode_prev=pnode;
+        while (pnode_prev->next && pnode_prev->next != pnode_next) {
+            pnode_prev=pnode_prev->next;
+            pnode_prev->pos++;
+        }
+        return;
+    }
 
-	if (!pnode_prev && l->list != pnode) {
-		/* The symbol will be the first in the list */
-		if (pnode->next)
-			(pnode->next)->prev=pnode->prev;
+    if (!pnode_prev && l->list != pnode) {
+        /* The symbol will be the first in the list */
+        if (pnode->next)
+            (pnode->next)->prev=pnode->prev;
 
-		(pnode->prev)->next=pnode->next;
-		pnode->prev=NULL;
-		pnode->next=l->list;
-		pnode->pos=0;
-		l->list->prev=pnode;
-		/* Increase in +1 the pos variable of all nodes after pnode */
-		l->list=pnode;
-		i=1;
-		while (pnode->next) {
-			pnode=pnode->next;
-			pnode->pos=i++;
-		}
-	}
+        (pnode->prev)->next=pnode->next;
+        pnode->prev=NULL;
+        pnode->next=l->list;
+        pnode->pos=0;
+        l->list->prev=pnode;
+        /* Increase in +1 the pos variable of all nodes after pnode */
+        l->list=pnode;
+        i=1;
+        while (pnode->next) {
+            pnode=pnode->next;
+            pnode->pos=i++;
+        }
+    }
 }
 
 
@@ -244,100 +244,100 @@ void _freqlist_promote(freqlist *l, node_freqlist *pnode)
    Return 1 if element if removed from the list, otherwise 0 */
 int _freqlist_dispromote(freqlist *l, node_freqlist *pnode)
 {
-	node_freqlist *pnode1, *pnode2, *pnode3=NULL;
+    node_freqlist *pnode1, *pnode2, *pnode3=NULL;
 
-	/* If the node has freq=0 is removed from the list */
-	if (pnode->freq == 0) {
-		if (pnode->next)
-			(pnode->next)->prev=pnode->prev;
-		if (pnode->prev)
-			(pnode->prev)->next=pnode->next;
-		pnode1=pnode->next;
-		if (pnode==l->list) {
-			l->list=pnode1;
-		}
-		free(pnode);
-		while (pnode1) {
-			pnode1->pos--;
-			pnode1=pnode1->next;
-		}
-		l->length--;
-		return 1;
-	}
+    /* If the node has freq=0 is removed from the list */
+    if (pnode->freq == 0) {
+        if (pnode->next)
+            (pnode->next)->prev=pnode->prev;
+        if (pnode->prev)
+            (pnode->prev)->next=pnode->next;
+        pnode1=pnode->next;
+        if (pnode==l->list) {
+            l->list=pnode1;
+        }
+        free(pnode);
+        while (pnode1) {
+            pnode1->pos--;
+            pnode1=pnode1->next;
+        }
+        l->length--;
+        return 1;
+    }
 
-	pnode1=pnode;
-	pnode2=pnode1->next;
+    pnode1=pnode;
+    pnode2=pnode1->next;
 
-	/* While exist a next node with more frequency than pnode
-	   or have same frequency and its ASCII code greater ... */
-	while ( pnode2 && node_cmp(pnode1, pnode2) < 0 ) {
-		pnode3=pnode2;
-		pnode2=pnode2->next;
-	}
+    /* While exist a next node with more frequency than pnode
+       or have same frequency and its ASCII code greater ... */
+    while ( pnode2 && node_cmp(pnode1, pnode2) < 0 ) {
+        pnode3=pnode2;
+        pnode2=pnode2->next;
+    }
 
-	if (pnode2 && pnode2!=pnode1->next) {
-		/* Previous and next of pnode1 point together */
-		(pnode1->next)->prev=pnode1->prev;
-		if (pnode1->prev)
-			(pnode1->prev)->next=pnode1->next;
-		/* pnode1 points at its news prev and next */
-		pnode1->next=pnode2;
-		pnode3=pnode1->prev;
-		pnode1->prev=pnode2->prev;
-		/* The new prev and next point to pnode1 */
-		pnode2->prev=pnode1;
-		(pnode1->prev)->next=pnode1;
+    if (pnode2 && pnode2!=pnode1->next) {
+        /* Previous and next of pnode1 point together */
+        (pnode1->next)->prev=pnode1->prev;
+        if (pnode1->prev)
+            (pnode1->prev)->next=pnode1->next;
+        /* pnode1 points at its news prev and next */
+        pnode1->next=pnode2;
+        pnode3=pnode1->prev;
+        pnode1->prev=pnode2->prev;
+        /* The new prev and next point to pnode1 */
+        pnode2->prev=pnode1;
+        (pnode1->prev)->next=pnode1;
 
-		/* pnode1 is assigned to the position it has its prev */
-		pnode1->pos=(pnode1->prev)->pos;
-		/* Decrease in 1 the pos variable of all nodes before pnode1 */
-		pnode2=pnode1;
-		while (pnode2->prev && pnode2->prev!=pnode3) {
-			pnode2=pnode2->prev;
-			pnode2->pos--;
-		}
-	}
+        /* pnode1 is assigned to the position it has its prev */
+        pnode1->pos=(pnode1->prev)->pos;
+        /* Decrease in 1 the pos variable of all nodes before pnode1 */
+        pnode2=pnode1;
+        while (pnode2->prev && pnode2->prev!=pnode3) {
+            pnode2=pnode2->prev;
+            pnode2->pos--;
+        }
+    }
 
-	/* If pnode2 doesn't exist, means that will be the last in the list,
-	   but if pnode3 is null, means that was already before this iteration */
-	if (!pnode2 && pnode3) {
-		/* Decrease in 1 the pos variable of all nodes before pnode1 */
-		pnode2=pnode1;
-		while (pnode2->next) {
-			pnode2=pnode2->next;
-			pnode2->pos--;
-		}
-		/* pnode3 points at the last of the list */
-		pnode3->next=pnode1;
-		/* Previous and next of pnode1 point together */
-		(pnode1->next)->prev=pnode1->prev;
-		if (pnode1->prev)
-			(pnode1->prev)->next=pnode1->next;
-		/* pnode1 points at its new prev */
-		pnode1->next=NULL;
-		pnode1->prev=pnode3;
-		pnode1->pos=pnode3->pos+1;
+    /* If pnode2 doesn't exist, means that will be the last in the list,
+       but if pnode3 is null, means that was already before this iteration */
+    if (!pnode2 && pnode3) {
+        /* Decrease in 1 the pos variable of all nodes before pnode1 */
+        pnode2=pnode1;
+        while (pnode2->next) {
+            pnode2=pnode2->next;
+            pnode2->pos--;
+        }
+        /* pnode3 points at the last of the list */
+        pnode3->next=pnode1;
+        /* Previous and next of pnode1 point together */
+        (pnode1->next)->prev=pnode1->prev;
+        if (pnode1->prev)
+            (pnode1->prev)->next=pnode1->next;
+        /* pnode1 points at its new prev */
+        pnode1->next=NULL;
+        pnode1->prev=pnode3;
+        pnode1->pos=pnode3->pos+1;
 
-	}
+    }
 
-	/* The symbol leaves the first position in the table, if it was */
-	if (pnode1->prev && l->list==pnode1) {
-		pnode2=pnode1->prev;
-		while (pnode2->prev) {
-			pnode2=pnode2->prev;
-		}
-		l->list=pnode2;
-	}
-	return 0;
+    /* The symbol leaves the first position in the table, if it was */
+    if (pnode1->prev && l->list==pnode1) {
+        pnode2=pnode1->prev;
+        while (pnode2->prev) {
+            pnode2=pnode2->prev;
+        }
+        l->list=pnode2;
+    }
+    return 0;
 }
 
 /*
  * Swap position with the next element in the list.
  *
- *     pnode0          pnode0	(could be NULL)
+ *     pnode0          pnode0    (could be NULL)
  *     pnode1    |-->  *pnode
  *     *pnode  ---     pnode1
- *     pnode2          pnode2	(could be NULL)
+ *     pnode2          pnode2    (could be NULL)
  *
  * If pnode0 is NULL, then l->list = pnode (first element
  * in the list).
@@ -345,28 +345,28 @@ int _freqlist_dispromote(freqlist *l, node_freqlist *pnode)
  * Returns 1 if the element were swapped, else 0.
  */
 int _freqlist_swap_with_prev(freqlist *l, node_freqlist * pnode) {
-	if (pnode->prev) {
-		node_freqlist * pnode1 = pnode->prev;
-		node_freqlist * pnode0 = pnode1->prev;
-		node_freqlist * pnode2 = pnode->next;
-		if (pnode0) {
-			pnode0->next = pnode;
-		} else {
-			l->list = pnode;
-		}
-		pnode->prev = pnode0;
-		pnode->next = pnode1;
-		pnode1->prev = pnode;
-		pnode1->next = pnode2;
-		if (pnode2) {
-			pnode2->prev = pnode1;
-		}
-		unsigned char pnode_pos = pnode->pos;
-		pnode->pos = pnode1->pos;
-		pnode1->pos = pnode_pos;
-		return 1;
-	}
-	return 0;
+    if (pnode->prev) {
+        node_freqlist * pnode1 = pnode->prev;
+        node_freqlist * pnode0 = pnode1->prev;
+        node_freqlist * pnode2 = pnode->next;
+        if (pnode0) {
+            pnode0->next = pnode;
+        } else {
+            l->list = pnode;
+        }
+        pnode->prev = pnode0;
+        pnode->next = pnode1;
+        pnode1->prev = pnode;
+        pnode1->next = pnode2;
+        if (pnode2) {
+            pnode2->prev = pnode1;
+        }
+        unsigned char pnode_pos = pnode->pos;
+        pnode->pos = pnode1->pos;
+        pnode1->pos = pnode_pos;
+        return 1;
+    }
+    return 0;
 }
 
 
@@ -375,22 +375,22 @@ int _freqlist_swap_with_prev(freqlist *l, node_freqlist * pnode) {
  * Returns the number of swaps made.
  */
 int freqlist_sort(freqlist *l) {
-	int swaps = 0;
-	if (!l->autosort) {
-		// Gnome sort implementation
-		node_freqlist * pnode = l->list;
-		while (pnode) {
-			if (pnode == l->list || node_cmp(pnode, pnode->prev) < 0) {
-				pnode = pnode->next;
-			} else {
-				//node_freqlist * pnode_prev = pnode->prev;
-				/* swap pnode and pnode->prev */
-				_freqlist_swap_with_prev(l, pnode);
-				swaps++;
-			}
-		}
-	}
-	return swaps;
+    int swaps = 0;
+    if (!l->autosort) {
+        // Gnome sort implementation
+        node_freqlist * pnode = l->list;
+        while (pnode) {
+            if (pnode == l->list || node_cmp(pnode, pnode->prev) < 0) {
+                pnode = pnode->next;
+            } else {
+                //node_freqlist * pnode_prev = pnode->prev;
+                /* swap pnode and pnode->prev */
+                _freqlist_swap_with_prev(l, pnode);
+                swaps++;
+            }
+        }
+    }
+    return swaps;
 }
 
 
@@ -400,9 +400,9 @@ int freqlist_sort(freqlist *l) {
  */
 int node_cmp(const node_freqlist *pnode1, const node_freqlist *pnode2)
 {
-	if ( pnode1->freq > pnode2->freq
-		 || (pnode1->freq == pnode2->freq && pnode1->symb < pnode2->symb) ) {
-		return 1;
-	}
-	return -1;
+    if ( pnode1->freq > pnode2->freq
+         || (pnode1->freq == pnode2->freq && pnode1->symb < pnode2->symb) ) {
+        return 1;
+    }
+    return -1;
 }

--- a/src/freqlist.c
+++ b/src/freqlist.c
@@ -34,7 +34,7 @@
 void freqlist_fprintf(FILE *f, const char *title,
                       const freqlist *freql, node_freqlist *pnode) {
     if (title)
-        fprintf(f, title);
+        fprintf(f, "%s", title);
     char *mark = "";
     char markup[16];
     if (pnode) {
@@ -91,15 +91,13 @@ freqlist* freqlist_create(unsigned char c) {
  * Free the memory of the list.
  */
 void freqlist_free(freqlist* l) {
-    node_freqlist *pnode;
-    pnode=l->list;
-    while (pnode->next)
-        pnode=pnode->next;
-    while (pnode->prev) {
-        pnode=pnode->prev;
-        free(pnode->next);
+    node_freqlist *pnode, *pnode_prev;
+    pnode = l->list;
+    while (pnode) {
+        pnode_prev = pnode;
+        pnode = pnode->next;
+        free(pnode_prev);
     }
-    free(pnode);
     free(l);
 }
 
@@ -113,8 +111,7 @@ node_freqlist *freqlist_find(const freqlist *l, unsigned char c) {
             to be more efficient */
     node_freqlist *pnode = l->list;
     while (pnode && c!=pnode->symb) pnode=pnode->next;
-    if (pnode && c==pnode->symb) return pnode;
-    return NULL;
+    return pnode;
 }
 
 

--- a/src/freqlist.c
+++ b/src/freqlist.c
@@ -26,23 +26,26 @@
 /*
  * Prints the list of frequencies.
  * @f: the output stream, eg. the stdout.
- * @msg: prints this message before the list (optional).
+ * @title: prints this message before the list (optional).
  * @freql: the frequency list.
  * @pnode: if not null the symbol is highlighted in
  *         the list (optional).
  */
-void freqlist_fprintf(FILE *f, const char *msg,
+void freqlist_fprintf(FILE *f, const char *title,
                       const freqlist *freql, node_freqlist *pnode)
 {
-	if (msg)
-		fprintf(f, msg);
+	if (title)
+		fprintf(f, title);
+    fprintf(f, "Symbol    Frequency   Pos\n");
+    fprintf(f, "-------------------------\n");
 	for (node_freqlist *pnode_i=freql->list; pnode_i; pnode_i=pnode_i->next)
-		fprintf(f, "Symb.: '%c' %02X   Freq.: %lu\tPos.: %2X%s\n",
+		fprintf(f, "'%c' %02X    %9lu    %2X%s\n",
                 (pnode_i->symb < 0x7F && pnode_i->symb >= 0x20) ? pnode_i->symb : '.',
                 pnode_i->symb,
                 pnode_i->freq,
                 pnode_i->pos,
                 pnode && pnode == pnode_i ? " *" : "");
+    fprintf(f, "-------------------------\n");
 	fprintf(f, "Size: %lu - Number of symbols: %d\n",
 			freql->size, freql->length);
 }

--- a/src/freqlist.c
+++ b/src/freqlist.c
@@ -121,12 +121,12 @@ node_freqlist *freqlist_add(freqlist *l, unsigned char c)
 	node_freqlist *pnode1, *pnode_prev;
 
 	/* This function promotes the position of the symbol in the list
-       after increase its frequency, or being created. */
+	   after increase its frequency, or being created. */
 	void _freqlist_promote(freqlist *l, node_freqlist *pnode);
 
 	pnode1=l->list;
 	while (pnode1 && c!=pnode1->symb) {
-        pnode_prev=pnode1;
+		pnode_prev=pnode1;
 		pnode1=pnode1->next;
 	}
 
@@ -184,7 +184,7 @@ void _freqlist_promote(freqlist *l, node_freqlist *pnode)
 			(pnode->next)->prev=pnode->prev;
 		/* pnode points at its new prev and next */
 		pnode->prev=pnode_prev;
-        pnode_next=pnode->next;
+		pnode_next=pnode->next;
 		pnode->next=pnode_prev->next;
 		/* The pnode new and prev point to pnode */
 		pnode_prev->next=pnode;
@@ -195,7 +195,7 @@ void _freqlist_promote(freqlist *l, node_freqlist *pnode)
 		/* Increase in +1 the pos variable of all nodes after pnode */
 		pnode_prev=pnode;
 		while (pnode_prev->next && pnode_prev->next != pnode_next) {
-            pnode_prev=pnode_prev->next;
+			pnode_prev=pnode_prev->next;
 			pnode_prev->pos++;
 		}
 		return;

--- a/src/freqlist.h
+++ b/src/freqlist.h
@@ -76,34 +76,34 @@ typedef struct _freqlist
 
 
 /*
- * Creates a list, and initializes the first node with the passed value.
- * Returns the list created.
+ * Create a list, and initialize the first node with the passed value.
+ * Return the list created.
  */
 freqlist* freqlist_create(unsigned char c);
 
 /*
- * Frees the memory of the list.
+ * Free the memory of the list.
  */
 void freqlist_free(freqlist* l);
 
 /*
- * Returns the node with the symbol 'c', or return NULL if not
+ * Return the node with the symbol 'c', or return NULL if not
  * in the list.
  */
 node_freqlist *freqlist_find(const freqlist* l, unsigned char c);
 
 /*
- * Increases the frequency of the symbol 'c' in +1,
- * and rearranges if necessary. If the symbol is not present
- * in the list, it adds them, an sets the frequency of the node in 1.
- * Returns the node with the symbol.
+ * Increase the frequency of the symbol 'c' in +1,
+ * and rearrange if necessary. If the symbol is not present
+ * in the list, add them, an set the frequency of the node in 1.
+ * Return the node with the symbol.
  */
 node_freqlist *freqlist_add(freqlist *l, unsigned char c);
 
 /*
- * Prints the list of frequencies.
+ * Print the list of frequencies.
  * @f: the output stream, eg. the stdout.
- * @title: prints this message before the list (optional).
+ * @title: print this message before the list (optional).
  * @freql: the frequency list.
  * @pnode: if not null the symbol is highlighted in
  *         the list (optional).
@@ -113,15 +113,15 @@ void freqlist_fprintf(FILE *f, const char *title,
 
 
 /*
- * Sorts the frequencies in case aren't sort.
- * Returns the number of swaps made.
+ * Sort the frequencies in case aren't sort.
+ * Return the number of swaps made.
  */
 int freqlist_sort(freqlist *l);
 
 
 /*
- * Compares by frequency of the node,
- * or symbol if the frequencies are equals.
+ * Compare by frequency of the node,
+ * or symbol if the frequencies are equal.
  */
 int node_cmp(const node_freqlist *pnode1, const node_freqlist *pnode2);
 

--- a/src/freqlist.h
+++ b/src/freqlist.h
@@ -68,7 +68,6 @@ typedef struct _freqlist
                                        (with the highest frequency). */
     int autosort;                   /* TRUE if the list must be sorted
                                        each time a symbol is added */
-    unsigned char freqs[256];       /* Frequencies of each symbol. */
     unsigned int length;            /* Numbers of different symbols
                                        in the list. */
     unsigned long size;             /* Numbers of symbols in the list. */

--- a/src/freqlist.h
+++ b/src/freqlist.h
@@ -18,8 +18,8 @@
    <http://www.gnu.org/licenses/>.  */
 
 
-#ifndef __FQ_FREQLIST_H
-#define __FQ_FREQLIST_H
+#ifndef _FREQLIST_H
+#define _FREQLIST_H
 
 
 #include <stdio.h>
@@ -39,19 +39,19 @@
  */
 typedef struct _node_freqlist
 {
-   unsigned char symb;				/* Referenced symbol. */
-   unsigned char pos;				/* Position in the list starting in 0
+    unsigned char symb;             /* Referenced symbol. */
+    unsigned char pos;              /* Position in the list starting in 0
                                        the first element in the list
                                        (higher frequency) */
-   unsigned long freq;				/* Occurrences of the character
-									   in the stream (frequency). */
-   struct _node_freqlist *prev;		/* Pointer to the previous node in
-									   the list, with frequency greater
-									   or equal than this. */
-   struct _node_freqlist *next;		/* Pointer to the next node in the list,
-									   with frequency less or equal
-									   than this. */
-   int debug_last_jump;             /* Number of symbols jumped in freqlist
+    unsigned long freq;             /* Occurrences of the character
+                                       in the stream (frequency). */
+    struct _node_freqlist *prev;    /* Pointer to the previous node in
+                                       the list, with frequency greater
+                                       or equal than this. */
+    struct _node_freqlist *next;    /* Pointer to the next node in the list,
+                                       with frequency less or equal
+                                       than this. */
+    int debug_last_jump;            /* Number of symbols jumped in freqlist
                                        last time symbol was found, e.g. if
                                        symbol was in pos 4 and them went to
                                        pos 1, the value will be 3 */
@@ -64,14 +64,14 @@ typedef struct _node_freqlist
  */
 typedef struct _freqlist
 {
-	node_freqlist *list;					/* Pointer to the first node
-											   (with the highest frequency). */
-	int autosort;							/* TRUE if the list must be sorted
-											   each time a symbol is added */
-	unsigned char freqs[256];				/* Frequencies of each symbol. */
-	unsigned int length;					/* Numbers of different symbols
-											   in the list. */
-	unsigned long size;						/* Numbers of symbols in the list. */
+    node_freqlist *list;            /* Pointer to the first node
+                                       (with the highest frequency). */
+    int autosort;                   /* TRUE if the list must be sorted
+                                       each time a symbol is added */
+    unsigned char freqs[256];       /* Frequencies of each symbol. */
+    unsigned int length;            /* Numbers of different symbols
+                                       in the list. */
+    unsigned long size;             /* Numbers of symbols in the list. */
 } freqlist;
 
 
@@ -126,4 +126,4 @@ int freqlist_sort(freqlist *l);
 int node_cmp(const node_freqlist *pnode1, const node_freqlist *pnode2);
 
 
-#endif /* __FQ_FREQLIST_H */
+#endif /* _FREQLIST_H */

--- a/src/freqlist.h
+++ b/src/freqlist.h
@@ -40,7 +40,9 @@
 typedef struct _node_freqlist
 {
    unsigned char symb;				/* Referenced symbol. */
-   unsigned char pos;				/* Position in the list */
+   unsigned char pos;				/* Position in the list starting in 0
+                                       the first element in the list
+                                       (higher frequency) */
    unsigned long freq;				/* Occurrences of the character
 									   in the stream (frequency). */
    struct _node_freqlist *prev;		/* Pointer to the previous node in

--- a/src/freqlist.h
+++ b/src/freqlist.h
@@ -97,12 +97,12 @@ node_freqlist *freqlist_add(freqlist *l, unsigned char c);
 /*
  * Prints the list of frequencies.
  * @f: the output stream, eg. the stdout.
- * @msg: prints this message before the list (optional).
+ * @title: prints this message before the list (optional).
  * @freql: the frequency list.
  * @pnode: if not null the symbol is highlighted in
  *         the list (optional).
  */
-void freqlist_fprintf(FILE *f, const char *msg,
+void freqlist_fprintf(FILE *f, const char *title,
                       const freqlist *freql, node_freqlist *pnode);
 
 

--- a/src/freqlist.h
+++ b/src/freqlist.h
@@ -76,10 +76,17 @@ typedef struct _freqlist
 
 
 /*
- * Create a list, and initialize the first node with the passed value.
- * Return the list created.
+ * Create a new freqlist.
  */
-freqlist* freqlist_create(unsigned char c);
+freqlist* freqlist_create();
+
+
+/*
+ * Create a new node.
+ */
+node_freqlist* freqlist_create_node(unsigned char c,
+                                    unsigned char pos,
+                                    unsigned long freq);
 
 /*
  * Free the memory of the list.

--- a/src/freqlist.h
+++ b/src/freqlist.h
@@ -51,6 +51,10 @@ typedef struct _node_freqlist
    struct _node_freqlist *next;		/* Pointer to the next node in the list,
 									   with frequency less or equal
 									   than this. */
+   int debug_last_jump;             /* Number of symbols jumped in freqlist
+                                       last time symbol was found, e.g. if
+                                       symbol was in pos 4 and them went to
+                                       pos 1, the value will be 3 */
 } node_freqlist;
 
 

--- a/src/main.c
+++ b/src/main.c
@@ -36,7 +36,7 @@
                 "    		for each byte in the stream\n" \
                 "  -h		display this help and exit\n" \
                 "\n" \
-                "With no FILE, read standard input.\n" \
+                "With no FILE, or when FILE is -, read standard input.\n" \
                 "\"Frequency Counter\" project v2.0.0-rc1: fq <https://github.com/mrsarm/fq>\n"
 
 
@@ -109,8 +109,13 @@ fq_data* init_options(int argc, char *argv[])
         }
 	}
     for (int index = optind; index < argc; index++) {
-        data->filename_in = argv[index];
-        break;
+        if (!data->filename_in) {
+            data->filename_in = argv[index];
+        } else {
+            fprintf(stderr, "%s error: extra operand '%s'\n", argv[0], argv[index]);
+            fprintf(stderr, "Try '%s -h' for more information.\n", argv[0]);
+            exit(ERROR_PARAM);
+        }
     }
 	return data;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -55,17 +55,23 @@ int main(int argc, char *argv[])
 
     int r = fq_data_init_resources(data);               // Initialize resources (files)
     switch (r) {
+        case OK: break;
         case ERROR_FILE_NOT_FOUND:
             fprintf(stderr, "Error: The input file `%s' cannot be opened.\n", data->filename_in);
             fq_data_free_resources(data);
             exit(ERROR_FILE_NOT_FOUND);
         case ERROR_MEM:
             error_mem(fq_data_free_resources, data);
+        default:
+            error_unknown_code(r, "fq_data_init_resources", fq_data_free_resources, data);
     }
     r = fq_count(data);                                 // Count the symbols
     switch (r) {
+        case OK: break;
         case ERROR_MEM:
             error_mem(fq_data_free_resources, data);
+        default:
+            error_unknown_code(r, "fq_count", fq_data_free_resources, data);
     }
 
     freqlist_fprintf(                                   // Print the frequencies

--- a/src/main.c
+++ b/src/main.c
@@ -119,7 +119,9 @@ fq_data* init_options(int argc, char *argv[])
 /* Ctrl+C handler */
 void ctrlc_handler(int sig) {
 	printf("\n");
-
+	if (!data->freql->autosort) {
+		freqlist_sort(data->freql);
+	}
 	if (data && data->freql) {
 		freqlist_fprintf(stdout, "> Final frequency table\n",   // Print the frequencies
 						 data->freql, NULL);

--- a/src/main.c
+++ b/src/main.c
@@ -57,9 +57,7 @@ int main(int argc, char *argv[])
     switch (r) {
         case OK: break;
         case ERROR_FILE_NOT_FOUND:
-            fprintf(stderr, "Error: The input file `%s' cannot be opened.\n", data->filename_in);
-            fq_data_free_resources(data);
-            exit(ERROR_FILE_NOT_FOUND);
+            error_cannot_open(r, "input", data->filename_in, fq_data_free_resources, data);
         case ERROR_MEM:
             error_mem(fq_data_free_resources, data);
         default:
@@ -114,7 +112,7 @@ fq_data* init_options(int argc, char *argv[])
         if (!data->filename_in) {
             data->filename_in = argv[index];
         } else {
-            fprintf(stderr, "%s error: extra operand `%s'\n", argv[0], argv[index]);
+            fprintf(stderr, "Error: extra operand `%s'\n", argv[index]);
             fprintf(stderr, "Try '%s -h' for more information.\n", argv[0]);
             exit(ERROR_PARAM);
         }

--- a/src/main.c
+++ b/src/main.c
@@ -50,10 +50,10 @@ fq_data* data;
 
 int main(int argc, char *argv[])
 {
-    data = init_options(argc, argv);            // Initialize data with command the arguments
     signal(SIGINT, ctrlc_handler);              // Initialize Ctrl+C signal
+    data = init_options(argc, argv);            // Initialize data with the command arguments
 
-    int r = fq_data_init_resources(data, NULL); // Initialize resources (files)
+    int r = fq_data_init_resources(data);       // Initialize resources (files)
     switch (r) {
         case ERROR_FILE_NOT_FOUND:
             fprintf(stderr, "Error: The input file `%s' cannot be opened.\n", data->filename_in);

--- a/src/main.c
+++ b/src/main.c
@@ -29,12 +29,12 @@
 
 
 #define USAGE   "Usage: %s [-hv] [FILE]\n" \
-                "Print the frequency table to standard output.\n" \
+                "Print the frequency table of FILE to standard output.\n" \
                 "\n" \
                 "Options:\n" \
-                "  -v		verbose mode, print the frequency table\n" \
-                "    		for each byte in the stream\n" \
-                "  -h		display this help and exit\n" \
+                "  -v       verbose mode, print the frequency table\n" \
+                "           for each byte in the stream\n" \
+                "  -h       display this help and exit\n" \
                 "\n" \
                 "With no FILE, or when FILE is -, read standard input.\n" \
                 "\"Frequency Counter\" project v2.0.0-rc1: fq <https://github.com/mrsarm/fq>\n"
@@ -50,41 +50,41 @@ fq_data* data;
 
 int main(int argc, char *argv[])
 {
-	data = init_options(argc, argv);			// Initialize data with command the arguments
-	signal(SIGINT, ctrlc_handler);				// Initialize Ctrl+C signal
+    data = init_options(argc, argv);            // Initialize data with command the arguments
+    signal(SIGINT, ctrlc_handler);              // Initialize Ctrl+C signal
 
-	int r = fq_data_init_resources(data, NULL);	// Initialize resources (files)
-	switch (r) {
-		case ERROR_FILE_NOT_FOUND:
-			fprintf(stderr, "Error: The input file `%s' cannot be opened.\n", data->filename_in);
-			  fq_data_free_resources(data);
-			  exit(ERROR_FILE_NOT_FOUND);
-		case ERROR_MEM:
-			error_mem(fq_data_free_resources, data);
-	}
-	r = fq_count(data);									// Count the symbols
-	switch (r) {
-		case ERROR_MEM:
-			error_mem(fq_data_free_resources, data);
-	}
+    int r = fq_data_init_resources(data, NULL); // Initialize resources (files)
+    switch (r) {
+        case ERROR_FILE_NOT_FOUND:
+            fprintf(stderr, "Error: The input file `%s' cannot be opened.\n", data->filename_in);
+            fq_data_free_resources(data);
+            exit(ERROR_FILE_NOT_FOUND);
+        case ERROR_MEM:
+            error_mem(fq_data_free_resources, data);
+    }
+    r = fq_count(data);                                  // Count the symbols
+    switch (r) {
+        case ERROR_MEM:
+            error_mem(fq_data_free_resources, data);
+    }
 
-	freqlist_fprintf(									// Print the frequencies
-	        stdout, "> Final frequency table\n", data->freql, NULL);
+    freqlist_fprintf(                                    // Print the frequencies
+            stdout, "> Final frequency table\n", data->freql, NULL);
 
-	fq_data_free_resources(data);						// Close file and free memory
+    fq_data_free_resources(data);                        // Close file and free memory
 
-	return 0;
+    return 0;
 }
 
 
 /* Initialize the global variables with the command options */
 fq_data* init_options(int argc, char *argv[])
 {
-	fq_data* data = fq_data_init();
-	if (!data) error_mem(NULL, NULL);
+    fq_data* data = fq_data_init();
+    if (!data) error_mem(NULL, NULL);
     opterr = 0;
-	int c;
-	while ((c = getopt(argc, argv, "hv")) != -1) {
+    int c;
+    while ((c = getopt(argc, argv, "dcvh")) != -1) {
         switch (c) {
             case 'h':
                 printf(USAGE, argv[0]);
@@ -96,41 +96,41 @@ fq_data* init_options(int argc, char *argv[])
 //                if (optopt == 'c') {
 //                    fprintf (stderr, "Option -%c requires an argument.\n", optopt);
 //                } else
-               	if (isprint (optopt)) {
-                    fprintf(stderr, "Error: unknown option `-%c'.\n", optopt);
-					fprintf(stderr, "Try '%s -h' for more information.\n", argv[0]);
+                   if (isprint (optopt)) {
+                    fprintf(stderr, "Unknown option `-%c'.\n", optopt);
+                    fprintf(stderr, "Try '%s -h' for more information.\n", argv[0]);
                 } else {
                     fprintf(stderr,
-                            "Error: unknown option character `\\x%x'.\n",
+                            "Unknown option character `\\x%x'.\n",
                             optopt);
                 }
-				exit(ERROR_PARAM);
+                exit(ERROR_PARAM);
         }
-	}
+    }
     for (int index = optind; index < argc; index++) {
         if (!data->filename_in) {
             data->filename_in = argv[index];
         } else {
-            fprintf(stderr, "Error: extra operand `%s'\n", argv[index]);
+            fprintf(stderr, "%s error: extra operand `%s'\n", argv[0], argv[index]);
             fprintf(stderr, "Try '%s -h' for more information.\n", argv[0]);
             exit(ERROR_PARAM);
         }
     }
-	return data;
+    return data;
 }
 
 
 /* Ctrl+C handler */
 void ctrlc_handler(int sig) {
-	printf("\n");
-	if (!data->freql->autosort) {
-		freqlist_sort(data->freql);
-	}
-	if (data && data->freql) {
-		freqlist_fprintf(stdout, "> Final frequency table\n",   // Print the frequencies
-						 data->freql, NULL);
-	}
-	exit(0);
+    printf("\n");
+    if (!data->freql->autosort) {
+        freqlist_sort(data->freql);
+    }
+    if (data && data->freql) {
+        freqlist_fprintf(stdout, "> Final frequency table\n",   // Print the frequencies
+                         data->freql, NULL);
+    }
+    exit(0);
 }
 
 /*  End program.  */

--- a/src/main.c
+++ b/src/main.c
@@ -28,16 +28,16 @@
 #include "fq.h"
 
 
-#define USAGE       "Usage: %s [-hv] [FILE]\n" \
-					"Print the frequency table to standard output.\n" \
-					"\n" \
-					"Options:\n" \
-	 				"  -v		verbose mode, print frequency table\n" \
-	  				"    		for each byte in the stream\n" \
-					"  -h		display this help and exit\n" \
-					"\n" \
-					"With no FILE, read standard input.\n" \
-					"\"Frequency Counter\" project v1.2.0: fq <https://github.com/mrsarm/fq>\n"
+#define USAGE   "Usage: %s [-hv] [FILE]\n" \
+                "Print the frequency table to standard output.\n" \
+                "\n" \
+                "Options:\n" \
+                "  -v		verbose mode, print frequency table\n" \
+                "    		for each byte in the stream\n" \
+                "  -h		display this help and exit\n" \
+                "\n" \
+                "With no FILE, read standard input.\n" \
+                "\"Frequency Counter\" project v1.2.0: fq <https://github.com/mrsarm/fq>\n"
 
 
 /* Initialize the global variables with the command arguments */

--- a/src/main.c
+++ b/src/main.c
@@ -56,8 +56,7 @@ int main(int argc, char *argv[])
 	int r = fq_data_init_resources(data, NULL);	// Initialize resources (files)
 	switch (r) {
 		case ERROR_FILE_NOT_FOUND:
-			fprintf(stderr, "%s error: The input file '%s' cannot be opened.\n",
-					  argv[0], data->filename_in);
+			fprintf(stderr, "Error: The input file `%s' cannot be opened.\n", data->filename_in);
 			  fq_data_free_resources(data);
 			  exit(ERROR_FILE_NOT_FOUND);
 		case ERROR_MEM:
@@ -98,11 +97,11 @@ fq_data* init_options(int argc, char *argv[])
 //                    fprintf (stderr, "Option -%c requires an argument.\n", optopt);
 //                } else
                	if (isprint (optopt)) {
-                    fprintf(stderr, "Unknown option `-%c'.\n", optopt);
+                    fprintf(stderr, "Error: unknown option `-%c'.\n", optopt);
 					fprintf(stderr, "Try '%s -h' for more information.\n", argv[0]);
                 } else {
                     fprintf(stderr,
-                            "Unknown option character `\\x%x'.\n",
+                            "Error: unknown option character `\\x%x'.\n",
                             optopt);
                 }
 				exit(ERROR_PARAM);
@@ -112,7 +111,7 @@ fq_data* init_options(int argc, char *argv[])
         if (!data->filename_in) {
             data->filename_in = argv[index];
         } else {
-            fprintf(stderr, "%s error: extra operand '%s'\n", argv[0], argv[index]);
+            fprintf(stderr, "Error: extra operand `%s'\n", argv[index]);
             fprintf(stderr, "Try '%s -h' for more information.\n", argv[0]);
             exit(ERROR_PARAM);
         }

--- a/src/main.c
+++ b/src/main.c
@@ -50,10 +50,10 @@ fq_data* data;
 
 int main(int argc, char *argv[])
 {
-    signal(SIGINT, ctrlc_handler);              // Initialize Ctrl+C signal
-    data = init_options(argc, argv);            // Initialize data with the command arguments
+    signal(SIGINT, ctrlc_handler);                      // Initialize Ctrl+C signal
+    data = init_options(argc, argv);                    // Initialize data with the command arguments
 
-    int r = fq_data_init_resources(data);       // Initialize resources (files)
+    int r = fq_data_init_resources(data);               // Initialize resources (files)
     switch (r) {
         case ERROR_FILE_NOT_FOUND:
             fprintf(stderr, "Error: The input file `%s' cannot be opened.\n", data->filename_in);
@@ -62,16 +62,16 @@ int main(int argc, char *argv[])
         case ERROR_MEM:
             error_mem(fq_data_free_resources, data);
     }
-    r = fq_count(data);                                  // Count the symbols
+    r = fq_count(data);                                 // Count the symbols
     switch (r) {
         case ERROR_MEM:
             error_mem(fq_data_free_resources, data);
     }
 
-    freqlist_fprintf(                                    // Print the frequencies
+    freqlist_fprintf(                                   // Print the frequencies
             stdout, "> Final frequency table\n", data->freql, NULL);
 
-    fq_data_free_resources(data);                        // Close file and free memory
+    fq_data_free_resources(data);                       // Close file and free memory
 
     return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -123,10 +123,10 @@ fq_data* init_options(int argc, char *argv[])
 /* Ctrl+C handler */
 void ctrlc_handler(int sig) {
     printf("\n");
-    if (!data->freql->autosort) {
-        freqlist_sort(data->freql);
-    }
     if (data && data->freql) {
+        if (!data->freql->autosort) {
+            freqlist_sort(data->freql);
+        }
         freqlist_fprintf(stdout, "> Final frequency table\n",   // Print the frequencies
                          data->freql, NULL);
     }

--- a/src/main.c
+++ b/src/main.c
@@ -93,10 +93,7 @@ fq_data* init_options(int argc, char *argv[])
                 data->verbose = TRUE;
                 break;
             case '?':
-//                if (optopt == 'c') {
-//                    fprintf (stderr, "Option -%c requires an argument.\n", optopt);
-//                } else
-                   if (isprint (optopt)) {
+                if (isprint (optopt)) {
                     fprintf(stderr, "Unknown option `-%c'.\n", optopt);
                     fprintf(stderr, "Try '%s -h' for more information.\n", argv[0]);
                 } else {

--- a/src/main.c
+++ b/src/main.c
@@ -32,12 +32,12 @@
                 "Print the frequency table to standard output.\n" \
                 "\n" \
                 "Options:\n" \
-                "  -v		verbose mode, print frequency table\n" \
+                "  -v		verbose mode, print the frequency table\n" \
                 "    		for each byte in the stream\n" \
                 "  -h		display this help and exit\n" \
                 "\n" \
                 "With no FILE, read standard input.\n" \
-                "\"Frequency Counter\" project v1.2.0: fq <https://github.com/mrsarm/fq>\n"
+                "\"Frequency Counter\" project v2.0.0-rc1: fq <https://github.com/mrsarm/fq>\n"
 
 
 /* Initialize the global variables with the command arguments */

--- a/src/main.c
+++ b/src/main.c
@@ -26,6 +26,7 @@
 #include "const.h"
 #include "freqlist.h"
 #include "fq.h"
+#include "util.h"
 
 
 #define USAGE   "Usage: %s [-hv] [FILE]\n" \
@@ -38,6 +39,8 @@
                 "\n" \
                 "With no FILE, or when FILE is -, read standard input.\n" \
                 "\"Frequency Counter\" project v2.0.0-rc1: fq <https://github.com/mrsarm/fq>\n"
+
+#define VERBOSE_TABLE   "> Final frequency table\n"
 
 
 /* Initialize the global variables with the command arguments */
@@ -57,23 +60,22 @@ int main(int argc, char *argv[])
     switch (r) {
         case OK: break;
         case ERROR_FILE_NOT_FOUND:
-            error_cannot_open(r, "input", data->filename_in, fq_data_free_resources, data);
+            error_cannot_open(r, "input", data->filename_in, (void*)fq_data_free_resources, data);
         case ERROR_MEM:
-            error_mem(fq_data_free_resources, data);
+            error_mem((void*)fq_data_free_resources, data);
         default:
-            error_unknown_code(r, "fq_data_init_resources", fq_data_free_resources, data);
+            error_unknown_code(r, "fq_data_init_resources", (void*)fq_data_free_resources, data);
     }
     r = fq_count(data);                                 // Count the symbols
     switch (r) {
         case OK: break;
         case ERROR_MEM:
-            error_mem(fq_data_free_resources, data);
+            error_mem((void*)fq_data_free_resources, data);
         default:
-            error_unknown_code(r, "fq_count", fq_data_free_resources, data);
+            error_unknown_code(r, "fq_count", (void*)fq_data_free_resources, data);
     }
 
-    freqlist_fprintf(                                   // Print the frequencies
-            stdout, "> Final frequency table\n", data->freql, NULL);
+    freqlist_fprintf(stdout, VERBOSE_TABLE, data->freql, NULL);
 
     fq_data_free_resources(data);                       // Close file and free memory
 
@@ -82,8 +84,7 @@ int main(int argc, char *argv[])
 
 
 /* Initialize the global variables with the command options */
-fq_data* init_options(int argc, char *argv[])
-{
+fq_data* init_options(int argc, char *argv[]) {
     fq_data* data = fq_data_init();
     if (!data) error_mem(NULL, NULL);
     opterr = 0;
@@ -128,8 +129,7 @@ void ctrlc_handler(int sig) {
         if (!data->freql->autosort) {
             freqlist_sort(data->freql);
         }
-        freqlist_fprintf(stdout, "> Final frequency table\n",   // Print the frequencies
-                         data->freql, NULL);
+        freqlist_fprintf(stdout, VERBOSE_TABLE, data->freql, NULL);
     }
     exit(0);
 }

--- a/src/util.c
+++ b/src/util.c
@@ -1,0 +1,69 @@
+/* util.c
+
+   Copyright (C) 2015-2021 Mariano Ruiz <mrsarm@gmail.com>
+   This file is part of the "Frequency Counter" project.
+
+   This project is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 3 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the "Frequency Counter" project; if not, see
+   <http://www.gnu.org/licenses/>.  */
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "const.h"
+#include "util.h"
+
+
+/*
+ * Print an error message with error_code and from string in the stderr, and abort
+ * the program after invoking the free_resources function.
+ */
+void error_unknown_code(int error_code, char *from,
+                        void(free_resources)(void*), void* data) {
+    if (free_resources) free_resources(data);
+    fprintf(stderr, "Error: unknown error code [%d] from `%s'.\n", error_code, from);
+    exit(ERROR_UNKNOWN);
+}
+
+/*
+ * Print an error message in the stderr that the file cannot be opened, and abort
+ * the program after invoking the free_resources function.
+ */
+void error_cannot_open(int error_code, char *file_type, char *filename,
+                       void(free_resources)(void*), void* data) {
+    if (free_resources) free_resources(data);
+    fprintf(stderr, "Error: The %s file `%s' cannot be opened.\n", file_type, filename);
+    exit(error_code);
+}
+
+/*
+ * Print error_code in the stderr, and abort
+ * the program after invoking the free_resources function.
+ */
+void fatal(int error_code,
+           char *error_msg,
+           void(free_resources)(void*), void* data) {
+    if (free_resources) free_resources(data);
+    fprintf(stderr, "%s", error_msg);
+    exit(error_code);
+}
+
+
+/*
+ * Print an insufficient memory error in the stderr, and abort
+ * the program after invoking the free_resources function.
+ */
+void error_mem(void(free_resources)(void*), void* data) {
+    fatal(ERROR_MEM, "Error: Insufficient memory.\n",
+          free_resources, data);
+}

--- a/src/util.h
+++ b/src/util.h
@@ -1,0 +1,54 @@
+/* util.h
+
+   Copyright (C) 2015-2019 Mariano Ruiz <mrsarm@gmail.com>
+   This file is part of the "Frequency Counter" project.
+
+   This project is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 3 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the "Frequency Counter" project; if not, see
+   <http://www.gnu.org/licenses/>.  */
+
+#ifndef _FQ_UTIL_H
+#define _FQ_UTIL_H
+
+
+/*
+ * Print an error message with error_code and from string in the stderr, and abort
+ * the program after invoking the free_resources function.
+ */
+void error_unknown_code(int error_code, char *from,
+                        void(free_resources)(void*), void* data);
+
+/*
+ * Print an error message in the stderr that the file cannot be opened, and abort
+ * the program after invoking the free_resources function.
+ */
+void error_cannot_open(int error_code, char *file_type, char *filename,
+                       void(free_resources)(void*), void* data);
+
+/*
+ * Print error_code in the stderr, and abort
+ * the program after invoking the free_resources function.
+ */
+void fatal(int error_code,
+           char *error_msg,
+           void(free_resources)(void*), void* data);
+
+
+/*
+ * Print an insufficient memory error in the stderr, and abort
+ * the program after invoking the free_resources function.
+ */
+void error_mem(void(free_resources)(void*), void* data);
+
+
+#endif /* _FQ_UTIL_H */

--- a/test/cheat.h
+++ b/test/cheat.h
@@ -1231,7 +1231,7 @@ terminates the program in case of a failure.
 */
 __attribute__ ((__io__))
 static void cheat_print_version(void) {
-	(void )fputs("CHEAT 1.0.3", stdout); /* This is always boring. */
+	(void )fputs("CHEAT 1.0.4", stdout); /* This is always boring. */
 	(void )fputc('\n', stdout);
 }
 

--- a/test/test_fq.c
+++ b/test/test_fq.c
@@ -25,13 +25,13 @@
 
 
 CHEAT_DECLARE(
-	fq_data* data;
+    fq_data* data;
 )
 
 CHEAT_TEAR_DOWN(
-	if (data) {
-		free_resources(data);
-	}
+    if (data) {
+        free_resources(data);
+    }
 )
 
 
@@ -39,16 +39,16 @@ CHEAT_TEAR_DOWN(
  *  DATA SET 1
  ***************/
 CHEAT_DECLARE(
-	unsigned char buff_1[] =		    { 4, 2, 3, 3, 6, 3, 4, 2, 6, 8 };
-	unsigned int expected_fq_1[][2] =	{ {3,3}, {2,2}, {4,2}, {6,2}, {8,1} };
+    unsigned char buff_1[] =            { 4, 2, 3, 3, 6, 3, 4, 2, 6, 8 };
+    unsigned int expected_fq_1[][2] =   { {3,3}, {2,2}, {4,2}, {6,2}, {8,1} };
 )
 CHEAT_TEST(expected_buff_out_ok,
-	data=count_buff(buff_1, ARRAY_SIZE(buff_1), FALSE);
-	cheat_assert(  freqlist_check(data->freql, expected_fq_1, ARRAY_SIZE(expected_fq_1))  );
+    data=count_buff(buff_1, ARRAY_SIZE(buff_1), FALSE);
+    cheat_assert(  freqlist_check(data->freql, expected_fq_1, ARRAY_SIZE(expected_fq_1))  );
 )
 CHEAT_TEST(expected_buff_out_ok_autosort,   // with autosort and verbose
-	data=count_buff(buff_1, ARRAY_SIZE(buff_1), TRUE);
-	cheat_assert(  freqlist_check(data->freql, expected_fq_1, ARRAY_SIZE(expected_fq_1))  );
+    data=count_buff(buff_1, ARRAY_SIZE(buff_1), TRUE);
+    cheat_assert(  freqlist_check(data->freql, expected_fq_1, ARRAY_SIZE(expected_fq_1))  );
 )
 
 
@@ -56,8 +56,8 @@ CHEAT_TEST(expected_buff_out_ok_autosort,   // with autosort and verbose
  *  DATA SET 2
  ***************/
 CHEAT_DECLARE(
-	unsigned char buff_2[] =			{ 0, 5, 3, 2, 2, 8, 5, 0, 6, 18, 10, 0 };
-	unsigned int expected_fq_2[][2] =	{ {0,3}, {2,2}, {5,2}, {3,1}, {6,1}, {8,1}, {10,1}, {18,1} };
+    unsigned char buff_2[] =            { 0, 5, 3, 2, 2, 8, 5, 0, 6, 18, 10, 0 };
+    unsigned int expected_fq_2[][2] =   { {0,3}, {2,2}, {5,2}, {3,1}, {6,1}, {8,1}, {10,1}, {18,1} };
 )
 CHEAT_TEST(expected_buff_out_2_ok,
    data=count_buff(buff_2, ARRAY_SIZE(buff_2), FALSE);
@@ -73,14 +73,14 @@ CHEAT_TEST(expected_buff_out_2_ok_autosort,
  *  DATA SET 3: word "banana"
  ****************************/
 CHEAT_DECLARE(
-	unsigned char buff_3[] =			{ 'b', 'a', 'n', 'a', 'n', 'a' };
-	unsigned int expected_fq_3[][2] =	{ {'a',3}, {'n',2}, {'b',1} };
+    unsigned char buff_3[] =            { 'b', 'a', 'n', 'a', 'n', 'a' };
+    unsigned int expected_fq_3[][2] =    { {'a',3}, {'n',2}, {'b',1} };
 )
 CHEAT_TEST(expected_buff_out_3_ok,
-   data=count_buff(buff_3, ARRAY_SIZE(buff_3), FALSE);
-   cheat_assert(  freqlist_check(data->freql, expected_fq_3, ARRAY_SIZE(expected_fq_3))  );
+    data=count_buff(buff_3, ARRAY_SIZE(buff_3), FALSE);
+    cheat_assert(  freqlist_check(data->freql, expected_fq_3, ARRAY_SIZE(expected_fq_3))  );
 )
 CHEAT_TEST(expected_buff_out_3_ok_autosort,
-   data=count_buff(buff_3, ARRAY_SIZE(buff_3), TRUE);
-   cheat_assert(  freqlist_check(data->freql, expected_fq_3, ARRAY_SIZE(expected_fq_3))  );
+    data=count_buff(buff_3, ARRAY_SIZE(buff_3), TRUE);
+    cheat_assert(  freqlist_check(data->freql, expected_fq_3, ARRAY_SIZE(expected_fq_3))  );
 )

--- a/test/test_fq.c
+++ b/test/test_fq.c
@@ -1,6 +1,6 @@
 /* test_fq.c
 
-   Copyright (C) 2015-2019 Mariano Ruiz <mrsarm@gmail.com>
+   Copyright (C) 2015-2021 Mariano Ruiz <mrsarm@gmail.com>
    This file is part of the "Frequency Counter" project.
 
    This project is free software; you can redistribute it and/or
@@ -19,6 +19,7 @@
 
 
 #include "cheat.h"
+#include "const.h"
 #include "fq.h"
 #include "test_util.h"
 
@@ -42,7 +43,11 @@ CHEAT_DECLARE(
 	unsigned int expected_fq_1[][2] =	{{3,3}, {2,2}, {4,2}, {6,2}, {8,1}};
 )
 CHEAT_TEST(expected_buff_out_ok,
-	data=count_buff(buff_1, ARRAY_SIZE(buff_1));
+	data=count_buff(buff_1, ARRAY_SIZE(buff_1), FALSE);
+	cheat_assert(  freqlist_check(data->freql, expected_fq_1, ARRAY_SIZE(expected_fq_1))  );
+)
+CHEAT_TEST(expected_buff_out_ok_autosort,   // with autosort and verbose
+	data=count_buff(buff_1, ARRAY_SIZE(buff_1), TRUE);
 	cheat_assert(  freqlist_check(data->freql, expected_fq_1, ARRAY_SIZE(expected_fq_1))  );
 )
 
@@ -55,7 +60,11 @@ CHEAT_DECLARE(
 	unsigned int expected_fq_2[][2] =	{{0,3}, {2,2}, {5,2}, {3,1}, {6,1}, {8,1}, {10,1}, {18,1}};
 )
 CHEAT_TEST(expected_buff_out_2_ok,
-   data=count_buff(buff_2, ARRAY_SIZE(buff_2));
+   data=count_buff(buff_2, ARRAY_SIZE(buff_2), FALSE);
+   cheat_assert(  freqlist_check(data->freql, expected_fq_2, ARRAY_SIZE(expected_fq_2))  );
+)
+CHEAT_TEST(expected_buff_out_2_ok_autosort,
+   data=count_buff(buff_2, ARRAY_SIZE(buff_2), TRUE);
    cheat_assert(  freqlist_check(data->freql, expected_fq_2, ARRAY_SIZE(expected_fq_2))  );
 )
 
@@ -68,6 +77,10 @@ CHEAT_DECLARE(
 	unsigned int expected_fq_3[][2] =	{{'a',3}, {'n',2}, {'b',1}};
 )
 CHEAT_TEST(expected_buff_out_3_ok,
-   data=count_buff(buff_3, ARRAY_SIZE(buff_3));
+   data=count_buff(buff_3, ARRAY_SIZE(buff_3), FALSE);
+   cheat_assert(  freqlist_check(data->freql, expected_fq_3, ARRAY_SIZE(expected_fq_3))  );
+)
+CHEAT_TEST(expected_buff_out_3_ok_autosort,
+   data=count_buff(buff_3, ARRAY_SIZE(buff_3), TRUE);
    cheat_assert(  freqlist_check(data->freql, expected_fq_3, ARRAY_SIZE(expected_fq_3))  );
 )

--- a/test/test_fq.c
+++ b/test/test_fq.c
@@ -21,7 +21,7 @@
 #include "cheat.h"
 #include "const.h"
 #include "fq.h"
-#include "test_util.h"
+#include "util_t.h"
 
 
 CHEAT_DECLARE(
@@ -40,7 +40,7 @@ CHEAT_TEAR_DOWN(
  ***************/
 CHEAT_DECLARE(
 	unsigned char buff_1[] =		    { 4, 2, 3, 3, 6, 3, 4, 2, 6, 8 };
-	unsigned int expected_fq_1[][2] =	{{3,3}, {2,2}, {4,2}, {6,2}, {8,1}};
+	unsigned int expected_fq_1[][2] =	{ {3,3}, {2,2}, {4,2}, {6,2}, {8,1} };
 )
 CHEAT_TEST(expected_buff_out_ok,
 	data=count_buff(buff_1, ARRAY_SIZE(buff_1), FALSE);
@@ -57,7 +57,7 @@ CHEAT_TEST(expected_buff_out_ok_autosort,   // with autosort and verbose
  ***************/
 CHEAT_DECLARE(
 	unsigned char buff_2[] =			{ 0, 5, 3, 2, 2, 8, 5, 0, 6, 18, 10, 0 };
-	unsigned int expected_fq_2[][2] =	{{0,3}, {2,2}, {5,2}, {3,1}, {6,1}, {8,1}, {10,1}, {18,1}};
+	unsigned int expected_fq_2[][2] =	{ {0,3}, {2,2}, {5,2}, {3,1}, {6,1}, {8,1}, {10,1}, {18,1} };
 )
 CHEAT_TEST(expected_buff_out_2_ok,
    data=count_buff(buff_2, ARRAY_SIZE(buff_2), FALSE);
@@ -74,7 +74,7 @@ CHEAT_TEST(expected_buff_out_2_ok_autosort,
  ****************************/
 CHEAT_DECLARE(
 	unsigned char buff_3[] =			{ 'b', 'a', 'n', 'a', 'n', 'a' };
-	unsigned int expected_fq_3[][2] =	{{'a',3}, {'n',2}, {'b',1}};
+	unsigned int expected_fq_3[][2] =	{ {'a',3}, {'n',2}, {'b',1} };
 )
 CHEAT_TEST(expected_buff_out_3_ok,
    data=count_buff(buff_3, ARRAY_SIZE(buff_3), FALSE);

--- a/test/test_util.c
+++ b/test/test_util.c
@@ -67,7 +67,7 @@ int freqlist_check(const freqlist* plist, const unsigned int expected_freqlist[]
 				   unsigned int expected_length) {
 
 	if (plist->length !=  expected_length) {
-		fprintf(stderr, "Different lengths. plist: %d - expected: %d\n", plist->length, expected_length);
+		fprintf(stderr, "Error: different lengths. plist %d - expected %d\n", plist->length, expected_length);
 		return FALSE;
 	}
 	node_freqlist *pnode = plist->list;
@@ -75,7 +75,7 @@ int freqlist_check(const freqlist* plist, const unsigned int expected_freqlist[]
 	while (pnode) {
 		if (pnode->symb != expected_freqlist[i][0]
 				|| pnode->freq != expected_freqlist[i][1]) {
-			fprintf(stderr, "Different values in plist. Pos.: %d - Symbols: %d, %d. "
+			fprintf(stderr, "Error: different values in plist. Pos. %d - Symbols %d, %d. "
 							"Frequencies: %lu, %u\n",
 					i, (int)pnode->symb, expected_freqlist[i][0], pnode->freq, expected_freqlist[i][1]);
 			return FALSE;

--- a/test/test_util.c
+++ b/test/test_util.c
@@ -1,6 +1,6 @@
 /* test_util.c
 
-   Copyright (C) 2015-2019 Mariano Ruiz <mrsarm@gmail.com>
+   Copyright (C) 2015-2021 Mariano Ruiz <mrsarm@gmail.com>
    This file is part of the "Frequency Counter" project.
 
    This project is free software; you can redistribute it and/or
@@ -26,14 +26,14 @@
 /**
  * Counts the buffer passed and returns the ``fq_data`` with the output data.
  */
-fq_data* count_buff(const unsigned char* buff_in, unsigned int buff_in_length) {
+fq_data* count_buff(const unsigned char* buff_in, unsigned int buff_in_length, int verbose) {
 
 	fq_data* data = fq_data_init();
 	if (!data) {
 		fprintf(stderr, "Error: Insufficient memory.\n");
 		exit(ERROR_MEM);
 	}
-	data->verbose = OUTPUT_VERBOSE;
+	data->verbose = verbose;
 	// Initialize with a memory stream
 	fq_data_init_resources_fi(data, fmemopen(buff_in, buff_in_length, "rb"));
 
@@ -44,7 +44,7 @@ fq_data* count_buff(const unsigned char* buff_in, unsigned int buff_in_length) {
 	}
 
 	freqlist_fprintf(stdout, "> Final frequency table\n", data->freql, NULL);
-	if (data->verbose) printf("\n-------------------------------------\n\n");
+	if (data->verbose) printf("\n=====================================\n\n");
 	return data;
 }
 
@@ -70,7 +70,7 @@ int freqlist_check(const freqlist* plist, const unsigned int expected_freqlist[]
 		fprintf(stderr, "Different lengths. plist: %d - expected: %d\n", plist->length, expected_length);
 		return FALSE;
 	}
-	node_freqlist*pnode = plist->list;
+	node_freqlist *pnode = plist->list;
 	int i = 0;
 	while (pnode) {
 		if (pnode->symb != expected_freqlist[i][0]

--- a/test/test_util.c
+++ b/test/test_util.c
@@ -39,8 +39,11 @@ fq_data* count_buff(const unsigned char* buff_in, unsigned int buff_in_length, i
 
 	int r = fq_count(data);
 	switch (r) {
+        case OK: break;
 		case ERROR_MEM:
 			error_mem(free_resources, data);
+        default:
+            error_unknown_code(r, "fq_count", fq_data_free_resources, data);
 	}
 
 	freqlist_fprintf(stdout, "> Final frequency table\n", data->freql, NULL);

--- a/test/test_util.h
+++ b/test/test_util.h
@@ -1,6 +1,6 @@
 /* test_util.h
 
-   Copyright (C) 2015-2019 Mariano Ruiz <mrsarm@gmail.com>
+   Copyright (C) 2015-2021 Mariano Ruiz <mrsarm@gmail.com>
    This file is part of the "Frequency Counter" project.
 
    This project is free software; you can redistribute it and/or
@@ -31,7 +31,7 @@
 /**
  * Counts the buffer passed and returns the ``fq_data`` with the output data.
  */
-fq_data* count_buff(const unsigned char* buff_in, unsigned int buff_in_length);
+fq_data* count_buff(const unsigned char* buff_in, unsigned int buff_in_length, int verbose);
 
 
 /*

--- a/test/util_t.c
+++ b/test/util_t.c
@@ -19,14 +19,15 @@
 
 
 #include <stdlib.h>
-#include "test_util.h"
+#include "util_t.h"
 #include "const.h"
+#include "util.h"
 
 
 /**
  * Counts the buffer passed and returns the ``fq_data`` with the output data.
  */
-fq_data* count_buff(const unsigned char* buff_in, unsigned int buff_in_length, int verbose) {
+fq_data* count_buff(unsigned char* buff_in, unsigned int buff_in_length, int verbose) {
 
 	fq_data* data = fq_data_init();
 	if (!data) {
@@ -41,9 +42,9 @@ fq_data* count_buff(const unsigned char* buff_in, unsigned int buff_in_length, i
 	switch (r) {
         case OK: break;
 		case ERROR_MEM:
-			error_mem(free_resources, data);
+			error_mem((void*)free_resources, data);
         default:
-            error_unknown_code(r, "fq_count", fq_data_free_resources, data);
+            error_unknown_code(r, "fq_count", (void*)fq_data_free_resources, data);
 	}
 
 	freqlist_fprintf(stdout, "> Final frequency table\n", data->freql, NULL);

--- a/test/util_t.c
+++ b/test/util_t.c
@@ -29,26 +29,26 @@
  */
 fq_data* count_buff(unsigned char* buff_in, unsigned int buff_in_length, int verbose) {
 
-	fq_data* data = fq_data_init();
-	if (!data) {
-		error_mem(NULL, NULL);
-	}
-	data->verbose = verbose;
-	// Initialize with a memory stream
-	fq_data_init_resources_fi(data, fmemopen(buff_in, buff_in_length, "rb"));
+    fq_data* data = fq_data_init();
+    if (!data) {
+        error_mem(NULL, NULL);
+    }
+    data->verbose = verbose;
+    // Initialize with a memory stream
+    fq_data_init_resources_fi(data, fmemopen(buff_in, buff_in_length, "rb"));
 
-	int r = fq_count(data);
-	switch (r) {
+    int r = fq_count(data);
+    switch (r) {
         case OK: break;
-		case ERROR_MEM:
-			error_mem((void*)free_resources, data);
+        case ERROR_MEM:
+            error_mem((void*)free_resources, data);
         default:
             error_unknown_code(r, "fq_count", (void*)fq_data_free_resources, data);
-	}
+    }
 
-	freqlist_fprintf(stdout, "> Final frequency table\n", data->freql, NULL);
-	if (data->verbose) printf("\n=====================================\n\n");
-	return data;
+    freqlist_fprintf(stdout, "> Final frequency table\n", data->freql, NULL);
+    if (data->verbose) printf("\n=====================================\n\n");
+    return data;
 }
 
 
@@ -57,8 +57,8 @@ fq_data* count_buff(unsigned char* buff_in, unsigned int buff_in_length, int ver
  */
 void free_resources(fq_data *data)
 {
-	if (data->freql) freqlist_free(data->freql);
-	free(data);
+    if (data->freql) freqlist_free(data->freql);
+    free(data);
 }
 
 
@@ -67,28 +67,28 @@ void free_resources(fq_data *data)
  * array format).
  */
 int freqlist_check(const freqlist* plist, const unsigned int expected_freqlist[][2],
-				   unsigned int expected_length) {
+                   unsigned int expected_length) {
 
-	if (plist->length !=  expected_length) {
-		fprintf(stderr, "Error: different lengths. plist %d - expected %d\n", plist->length, expected_length);
-		return FALSE;
-	}
-	node_freqlist *pnode = plist->list;
-	int i = 0;
-	while (pnode) {
-		if (pnode->symb != expected_freqlist[i][0]
-				|| pnode->freq != expected_freqlist[i][1]) {
-			fprintf(stderr, "Error: different values in plist. Pos. %d - Symbols %d, %d. "
-							"Frequencies: %lu, %u\n",
-					i, (int)pnode->symb, expected_freqlist[i][0], pnode->freq, expected_freqlist[i][1]);
-			return FALSE;
-		}
-		if (pnode->pos != i) {
-			fprintf(stderr, "Error: different pos value in node. Pos. expected %d - Pos. %d\n",
-					        i, pnode->pos);
-		}
-		pnode = pnode->next;
-		i++;
-	}
-	return TRUE;
+    if (plist->length !=  expected_length) {
+        fprintf(stderr, "Error: different lengths. plist %d - expected %d\n", plist->length, expected_length);
+        return FALSE;
+    }
+    node_freqlist *pnode = plist->list;
+    int i = 0;
+    while (pnode) {
+        if (pnode->symb != expected_freqlist[i][0]
+                || pnode->freq != expected_freqlist[i][1]) {
+            fprintf(stderr, "Error: different values in plist. Pos. %d - Symbols %d, %d. "
+                            "Frequencies: %lu, %u\n",
+                    i, (int)pnode->symb, expected_freqlist[i][0], pnode->freq, expected_freqlist[i][1]);
+            return FALSE;
+        }
+        if (pnode->pos != i) {
+            fprintf(stderr, "Error: different pos value in node. Pos. expected %d - Pos. %d\n",
+                            i, pnode->pos);
+        }
+        pnode = pnode->next;
+        i++;
+    }
+    return TRUE;
 }

--- a/test/util_t.c
+++ b/test/util_t.c
@@ -83,6 +83,10 @@ int freqlist_check(const freqlist* plist, const unsigned int expected_freqlist[]
 					i, (int)pnode->symb, expected_freqlist[i][0], pnode->freq, expected_freqlist[i][1]);
 			return FALSE;
 		}
+		if (pnode->pos != i) {
+			fprintf(stderr, "Error: different pos value in node. Pos. expected %d - Pos. %d\n",
+					        i, pnode->pos);
+		}
 		pnode = pnode->next;
 		i++;
 	}

--- a/test/util_t.c
+++ b/test/util_t.c
@@ -31,8 +31,7 @@ fq_data* count_buff(unsigned char* buff_in, unsigned int buff_in_length, int ver
 
 	fq_data* data = fq_data_init();
 	if (!data) {
-		fprintf(stderr, "Error: Insufficient memory.\n");
-		exit(ERROR_MEM);
+		error_mem(NULL, NULL);
 	}
 	data->verbose = verbose;
 	// Initialize with a memory stream

--- a/test/util_t.c
+++ b/test/util_t.c
@@ -63,7 +63,7 @@ void free_resources(fq_data *data)
 
 
 /*
- * Checks if ``list`` is equals to ``expected_freqlist`` (second list is in
+ * Checks if plist is equals to expected_freqlist (second list is in
  * array format).
  */
 int freqlist_check(const freqlist* plist, const unsigned int expected_freqlist[][2],
@@ -86,6 +86,7 @@ int freqlist_check(const freqlist* plist, const unsigned int expected_freqlist[]
         if (pnode->pos != i) {
             fprintf(stderr, "Error: different pos value in node. Pos. expected %d - Pos. %d\n",
                             i, pnode->pos);
+            return FALSE;
         }
         pnode = pnode->next;
         i++;

--- a/test/util_t.h
+++ b/test/util_t.h
@@ -18,8 +18,8 @@
    <http://www.gnu.org/licenses/>.  */
 
 
-#ifndef _FQ_TEST_UTIL_H
-#define _FQ_TEST_UTIL_H
+#ifndef _FQ_UTIL_T_H
+#define _FQ_UTIL_T_H
 
 #include <fq.h>
 
@@ -31,7 +31,7 @@
 /**
  * Counts the buffer passed and returns the ``fq_data`` with the output data.
  */
-fq_data* count_buff(const unsigned char* buff_in, unsigned int buff_in_length, int verbose);
+fq_data* count_buff(unsigned char* buff_in, unsigned int buff_in_length, int verbose);
 
 
 /*
@@ -48,4 +48,4 @@ int freqlist_check(const freqlist* plist, const unsigned int expected_freqlist[]
 				   unsigned int expected_length);
 
 
-#endif  /* _FQ_TEST_UTIL_H */
+#endif  /* _FQ_UTIL_T_H */

--- a/test/util_t.h
+++ b/test/util_t.h
@@ -41,7 +41,7 @@ void free_resources(fq_data *data);
 
 
 /*
- * Checks if ``list`` is equals to ``expected_freqlist`` (second list is in
+ * Checks if plist is equals to expected_freqlist (second list is in
  * array format).
  */
 int freqlist_check(const freqlist* plist, const unsigned int expected_freqlist[][2],


### PR DESCRIPTION
- Frequencies are better formatted as a table
- In verbose mode add better marks about the current symbol
- Allow the use of `-` as argument instead of no argument to set the input stream as source
-  Fix when interrupting the program with _Ctrl+C_ the frequency output was unsorted
- Fix pointer truncate bug
- Better error handling and error messages
- A lot of code refactor and formatting. Replace tabs with 4 spaces in source code files.
- CTest configuration and improved tests
- Remove redundant `freqlist.freqs`