### PR TITLE
Fix concurrent CI jobs setup

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -3,8 +3,10 @@ name: CMake
 on: [push, pull_request]
 
 jobs:
-  pre_job:
-    name: Pre Job
+
+  skip_check:
+
+    name: Skip Check
     runs-on: ubuntu-latest
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
@@ -12,13 +14,14 @@ jobs:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@master
         with:
+          concurrent_skipping: 'same_content_newer'
           paths_ignore: '["**.md"]'
 
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    needs: skip_check
+    if: ${{ needs.skip_check.outputs.should_skip != 'true' }}
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
- `concurrent_skipping: 'same_content_newer'` allows to skip better concurrent jobs.
- Rename skip job.